### PR TITLE
Fixed BlobPrefixes being ignored

### DIFF
--- a/lib/azure/storage/blob/serialization.rb
+++ b/lib/azure/storage/blob/serialization.rb
@@ -122,6 +122,16 @@ module Azure::Storage
           end
         end
 
+        if (((xml > "Blobs") > "BlobPrefix") > "Name").any?
+          if xml.Blobs.BlobPrefix.Name.count == 0
+            results.push(xml.Blobs.BlobPrefix.Name.text)
+          else
+            xml.Blobs.BlobPrefix.each { |blob_prefix|
+              results.push(blob_prefix.text)
+            }
+          end
+        end
+
         results
       end
       

--- a/lib/azure/storage/blob/serialization.rb
+++ b/lib/azure/storage/blob/serialization.rb
@@ -122,17 +122,25 @@ module Azure::Storage
           end
         end
 
-        if (((xml > "Blobs") > "BlobPrefix") > "Name").any?
-          if xml.Blobs.BlobPrefix.Name.count == 0
-            results.push(xml.Blobs.BlobPrefix.Name.text)
+        if ((xml > "Blobs") > "BlobPrefix").any?
+          if xml.Blobs.BlobPrefix.count == 0
+            results.push(blob_prefix_from_xml(xml.Blobs.BlobPrefix))
           else
             xml.Blobs.BlobPrefix.each { |blob_prefix|
-              results.push(blob_prefix.text)
+              results.push(blob_prefix_from_xml(blob_prefix))
             }
           end
         end
 
         results
+      end
+
+      def self.blob_prefix_from_xml(xml)
+        xml = slopify(xml)
+        expect_node("BlobPrefix", xml)
+
+        name = xml.Name.text if (xml > "Name").any?
+        name
       end
       
       def self.blob_from_xml(xml)

--- a/test/integration/blob/list_blobs_test.rb
+++ b/test/integration/blob/list_blobs_test.rb
@@ -30,7 +30,7 @@ describe Azure::Storage::Blob::BlobService do
 
   describe '#list_blobs' do
     let(:container_name) { ContainerNameHelper.name }
-    let(:blob_names) { ["blobname0","blobname1","blobname2","blobname3"] }
+    let(:blob_names) { ["blobname0","blobname1","blobname2","blobname3","prefix0/blobname4","prefix0/blobname5", "prefix0/child_prefix0/blobname6"] }
     let(:content) { content = ""; 1024.times.each{|i| content << "@" }; content }
     let(:metadata) { { "CustomMetadataProperty"=>"CustomMetadataValue" } }
     let(:options) { { :content_type=>"application/foo", :metadata => metadata } }
@@ -55,7 +55,18 @@ describe Azure::Storage::Blob::BlobService do
     it 'lists the available blobs with prefix' do
       result = subject.list_blobs container_name, { :prefix => "blobname0" }
       result.length.must_equal 1
+      result = subject.list_blobs container_name, { :prefix => "prefix0/" }
+      result.length.must_equal 3
     end
+
+    it 'lists the available blobs and prefixes with delimiter and prefix' do
+      result = subject.list_blobs container_name, { :delimiter => "/" }
+      result.length.must_equal 5
+      result = subject.list_blobs container_name, { :delimiter => "/", :prefix => "prefix0/" }
+      result.length.must_equal 3
+      result = subject.list_blobs container_name, { :delimiter => "/", :prefix => "prefix0/child_prefix0/" }
+      result.length.must_equal 1
+    end    
 
     it 'lists the available blobs with max results and marker ' do
       result = subject.list_blobs container_name, { :max_results => 2 }

--- a/test/unit/blob/blob_service_test.rb
+++ b/test/unit/blob/blob_service_test.rb
@@ -532,7 +532,7 @@ describe Azure::Storage::Blob::BlobService do
           subject.list_blobs container_name, options
         end
 
-        it 'modifies the URI query parameters when provided a :prefix value' do
+        it 'modifies the URI query parameters when provided a :delimiter value' do
           query['delimiter'] = 'delim'
           options = {:delimiter => 'delim'}
           subject.list_blobs container_name, options


### PR DESCRIPTION
Fix for https://github.com/Azure/azure-storage-ruby/issues/41

Changed `blob_enumeration_results_from_xml` to include BlobPrefixes from XML response as strings. Note that this causes `list_blobs` to now return an array of mixed types (possibly only when a non-nil delimiter is specified).