### PR TITLE
Fix InvalidOptionsError in signed_url with full blob url

### DIFF
--- a/lib/azure/storage/core/auth/shared_access_signature_generator.rb
+++ b/lib/azure/storage/core/auth/shared_access_signature_generator.rb
@@ -313,9 +313,9 @@ module Azure::Storage::Core
       def signed_uri(uri, use_account_sas, options)
         parsed_query = CGI::parse(uri.query || '').inject({}){|memo,(k,v)| memo[k.to_sym] = v; memo}
 
-        if options[:service_type] == nil and uri.host != nil
+        if options[:service] == nil and uri.host != nil
           host_splits = uri.host.split('.')
-          options[:service_type] = host_splits[1] if host_splits.length > 1 && host_splits[0] == @account_name
+          options[:service] = host_splits[1].chr if host_splits.length > 1 && host_splits[0] == @account_name
         end
 
         sas_params = if use_account_sas

--- a/test/unit/core/auth/shared_access_signature_test.rb
+++ b/test/unit/core/auth/shared_access_signature_test.rb
@@ -111,5 +111,13 @@ describe Azure::Storage::Core::Auth::SharedAccessSignature do
       query_hash['sip'].must_equal '168.1.5.60-168.1.5.70'
       query_hash['spr'].must_equal 'https,http'
     end
+
+    it 'correctly maps service type when given full blob url and no service' do
+      blob_url = File.join("https://#{access_account_name}.blob.core.windows.net", path)
+      uri = URI(subject.signed_uri(URI(blob_url), true, account_options.merge(service: nil)))
+      query_hash = Hash[URI.decode_www_form(uri.query)]
+      query_hash['ss'].must_equal 'b'
+      query_hash['srt'].must_equal 'b'
+    end
   end
 end


### PR DESCRIPTION
I was getting this error when using signed_url and passing in the full url to the blob:

An Azure::Storage::InvalidOptionsError occurred in foo#bar:
invalid options {:service_type=>"blob"} provided for SAS token generate

Looks like the wrong key was referenced (:service_type instead of :service) and breaking down the azure storage url was taking "blob" which wouldn't correctly map instead of the first character "b".