### PR TITLE
Remove wrong content-encoding handling

### DIFF
--- a/lib/azure/storage/blob/blob_service.rb
+++ b/lib/azure/storage/blob/blob_service.rb
@@ -45,25 +45,7 @@ module Azure::Storage
       end
       
       def call(method, uri, body=nil, headers={})
-        # Force the request.body to the content encoding of specified in the header
-        # (content encoding probably shouldn't be used this way)
-        if headers && !body.nil?
-          if headers['Content-Encoding'].nil?
-            Service::StorageService.with_header headers, 'Content-Encoding', body.encoding.to_s
-          else
-            body.force_encoding(headers['Content-Encoding'])
-          end
-        end
-
-        response = super
-
-        # Force the response.body to the content encoding of specified in the header.
-        # content-encoding is echo'd back for the blob and is used to store the encoding of the octet stream
-        if !response.nil? && !response.body.nil? && response.headers['content-encoding']
-          response.body.force_encoding(response.headers['content-encoding'])
-        end
-
-        response
+        super
       end
 
       # Public: Get a list of Containers from the server.

--- a/test/integration/blob/blob_gb18030_test.rb
+++ b/test/integration/blob/blob_gb18030_test.rb
@@ -166,10 +166,8 @@ describe 'Blob GB-18030' do
     GB18030TestStrings.get.each { |k,v|
       blob_name = 'Read/Write Block Blob Content GB18030 for ' + k
       content = v.encode('GB18030')
-      options = { :content_encoding=> 'GB18030'}
       subject.create_block_blob container_name, blob_name, content, options
       blob, returned_content = subject.get_blob container_name, blob_name
-      returned_content.force_encoding(blob.properties[:content_encoding])
       returned_content.must_equal content
     }
   end
@@ -177,7 +175,6 @@ describe 'Blob GB-18030' do
   it 'Read/Write Blob Page Content UTF-8' do
     GB18030TestStrings.get.each { |k,v|
       blob_name = 'Read/Write Page Blob Content UTF-8 for ' + k
-      options = { :content_encoding=> 'UTF-8'}
       content = v.encode('UTF-8')
       while content.bytesize < 512 do
         content << 'X'
@@ -185,7 +182,6 @@ describe 'Blob GB-18030' do
       subject.create_page_blob container_name, blob_name, 512, options
       subject.put_blob_pages container_name, blob_name, 0, 511, content
       blob, returned_content = subject.get_blob container_name, blob_name
-      returned_content.force_encoding(blob.properties[:content_encoding])
       returned_content.must_equal content
     }
   end
@@ -193,7 +189,6 @@ describe 'Blob GB-18030' do
   it 'Read/Write Blob Page Content GB18030' do
     GB18030TestStrings.get.each { |k,v|
       blob_name = 'Read/Write Page Blob Content GB18030 for ' + k
-      options = { :content_encoding=> 'GB18030'}
       content = v.encode('GB18030')
       while content.bytesize < 512 do
         content << 'X'
@@ -201,7 +196,6 @@ describe 'Blob GB-18030' do
       subject.create_page_blob container_name, blob_name, 512, options
       subject.put_blob_pages container_name, blob_name, 0, 511, content
       blob, returned_content = subject.get_blob container_name, blob_name
-      returned_content.force_encoding(blob.properties[:content_encoding])
       returned_content.must_equal content
     }
   end


### PR DESCRIPTION
Ruby's String#encoding handles character encodings.
But HTTP's Content-Encoding handles compression format like gzip or deflate.
They are different.
https://msdn.microsoft.com/library/windows/desktop/aa383955.aspx

fixes #20 
