### PR TITLE
Changes for v0.11.1-preview

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,10 @@
+2016.09 - version 0.11.1-preview
+
+ALL
+* Added the support for setting the client request ID via the "request_id" parameter.
+* Added the retry for the timeout errors.
+* Added the retry for the connection reset error.
+
 2016.08 - version 0.11.0-preview
 
 ALL

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,9 @@ ALL
 * Added the retry for the timeout errors.
 * Added the retry for the connection reset error.
 
+BLOB
+* Fixed the issue where "list_blobs" doesn't work when delimiter is specified. (https://github.com/Azure/azure-storage-ruby/issues/41)
+
 2016.08 - version 0.11.0-preview
 
 ALL

--- a/lib/azure/storage/blob/append.rb
+++ b/lib/azure/storage/blob/append.rb
@@ -47,6 +47,8 @@ module Azure::Storage
     #                                  and also can be used to attach additional metadata
     # * +:metadata+                  - Hash. Custom metadata values to store with the blob.
     # * +:timeout+                   - Integer. A timeout in seconds.
+    # * +:request_id+                - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+    #                                  in the analytics logs when storage analytics logging is enabled.
     # * +:if_modified_since+         - String. A DateTime value. Specify this conditional header to create a new blob 
     #                                  only if the blob has been modified since the specified date/time. If the blob has not been modified, 
     #                                  the Blob service returns status code 412 (Precondition Failed).
@@ -69,7 +71,7 @@ module Azure::Storage
 
       uri = blob_uri(container, blob, query)
 
-      headers = StorageService.service_properties_headers
+      headers = StorageService.common_headers
 
       # set x-ms-blob-type to AppendBlob
       StorageService.with_header headers, 'x-ms-blob-type', 'AppendBlob'
@@ -90,7 +92,7 @@ module Azure::Storage
       add_blob_conditional_headers options, headers
 
       # call PutBlob with empty body
-      response = call(:put, uri, nil, headers)
+      response = call(:put, uri, nil, headers, options)
 
       result = Serialization.blob_from_headers(response.headers)
       result.name = blob
@@ -116,6 +118,8 @@ module Azure::Storage
     # * +:max_size+                  - Integer. The max length in bytes permitted for the append blob
     # * +:append_position+           - Integer. A number indicating the byte offset to compare. It will succeed only if the append position is equal to this number
     # * +:timeout+                   - Integer. A timeout in seconds.
+    # * +:request_id+                - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+    #                                  in the analytics logs when storage analytics logging is enabled.
     # * +:if_modified_since+         - String. A DateTime value. Specify this conditional header to append a block only if 
     #                                  the blob has been modified since the specified date/time. If the blob has not been modified, 
     #                                  the Blob service returns status code 412 (Precondition Failed).
@@ -138,13 +142,13 @@ module Azure::Storage
 
       uri = blob_uri(container, blob, query)
 
-      headers = StorageService.service_properties_headers
+      headers = StorageService.common_headers
       StorageService.with_header headers, 'Content-MD5', options[:content_md5]
       StorageService.with_header headers, 'x-ms-lease-id', options[:lease_id]
       
       add_blob_conditional_headers options, headers
 
-      response = call(:put, uri, content, headers)
+      response = call(:put, uri, content, headers, options)
       result = Serialization.blob_from_headers(response.headers)
       result.name = blob
 

--- a/lib/azure/storage/blob/block.rb
+++ b/lib/azure/storage/blob/block.rb
@@ -69,6 +69,8 @@ module Azure::Storage
     #                                  and also can be used to attach additional metadata
     # * +:metadata+                  - Hash. Custom metadata values to store with the blob.
     # * +:timeout+                   - Integer. A timeout in seconds.
+    # * +:request_id+                - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+    #                                  in the analytics logs when storage analytics logging is enabled.
     # * +:if_modified_since+         - String. A DateTime value. Specify this conditional header to create a new blob 
     #                                  only if the blob has been modified since the specified date/time. If the blob has not been modified, 
     #                                  the Blob service returns status code 412 (Precondition Failed).
@@ -91,7 +93,7 @@ module Azure::Storage
 
       uri = blob_uri(container, blob, query)
 
-      headers = StorageService.service_properties_headers
+      headers = StorageService.common_headers
 
       # set x-ms-blob-type to BlockBlob
       StorageService.with_header headers, 'x-ms-blob-type', 'BlockBlob'
@@ -109,7 +111,7 @@ module Azure::Storage
       add_blob_conditional_headers options, headers
 
       # call PutBlob with empty body
-      response = call(:put, uri, content, headers)
+      response = call(:put, uri, content, headers, options)
 
       result = Serialization.blob_from_headers(response.headers)
       result.name = blob
@@ -132,6 +134,8 @@ module Azure::Storage
     # Accepted key/value pairs in options parameter are:
     # * +:content_md5+           - String. Content MD5 for the request contents.
     # * +:timeout+               - Integer. A timeout in seconds.
+    # * +:request_id+            - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+    #                              in the analytics logs when storage analytics logging is enabled.
     #
     # See http://msdn.microsoft.com/en-us/library/azure/dd135726.aspx
     #
@@ -143,10 +147,10 @@ module Azure::Storage
 
       uri = blob_uri(container, blob, query)
 
-      headers = StorageService.service_properties_headers
+      headers = StorageService.common_headers
       StorageService.with_header headers, 'Content-MD5', options[:content_md5]
 
-      response = call(:put, uri, content, headers)
+      response = call(:put, uri, content, headers, options)
       response.headers['Content-MD5']
     end
 
@@ -186,6 +190,8 @@ module Azure::Storage
     #                                  and also can be used to attach additional metadata
     # * +:metadata+                  - Hash. Custom metadata values to store with the blob.
     # * +:timeout+                   - Integer. A timeout in seconds.
+    # * +:request_id+                - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+    #                                  in the analytics logs when storage analytics logging is enabled.
     #
     # This operation also supports the use of conditional headers to commit the block list if a specified condition is met.
     # For more information, see https://msdn.microsoft.com/en-us/library/azure/dd179371.aspx
@@ -199,7 +205,7 @@ module Azure::Storage
 
       uri = blob_uri(container, blob, query)
 
-      headers = StorageService.service_properties_headers
+      headers = StorageService.common_headers
       unless options.empty?
         StorageService.with_header headers, 'Content-MD5', options[:transactional_md5]
         StorageService.with_header headers, 'x-ms-blob-content-type', options[:content_type]
@@ -214,7 +220,7 @@ module Azure::Storage
       end
 
       body = Serialization.block_list_to_xml(block_list)
-      call(:put, uri, body, headers)
+      call(:put, uri, body, headers, options)
       nil
     end
 
@@ -230,17 +236,19 @@ module Azure::Storage
     #
     # ==== Attributes
     #
-    # * +container+       - String. The container name.
-    # * +blob+            - String. The blob name.
-    # * +options+         - Hash. Optional parameters.
+    # * +container+                 - String. The container name.
+    # * +blob+                      - String. The blob name.
+    # * +options+                   - Hash. Optional parameters.
     #
     # ==== Options
     #
     # Accepted key/value pairs in options parameter are:
-    # * +:blocklist_type+ - Symbol. One of :all, :committed, :uncommitted. Defaults to :all (optional)
-    # * +:snapshot+       - String. An opaque DateTime value that specifies the blob snapshot to
-    #   retrieve information from. (optional)
-    # * +:timeout+        - Integer. A timeout in seconds.
+    # * +:blocklist_type+           - Symbol. One of :all, :committed, :uncommitted. Defaults to :all (optional)
+    # * +:snapshot+                 - String. An opaque DateTime value that specifies the blob snapshot to
+    #                                 retrieve information from. (optional)
+    # * +:timeout+                  - Integer. A timeout in seconds.
+    # * +:request_id+               - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+    #                                 in the analytics logs when storage analytics logging is enabled.
     #
     # See http://msdn.microsoft.com/en-us/library/azure/dd179400.aspx
     #
@@ -256,7 +264,7 @@ module Azure::Storage
 
       uri = blob_uri(container, blob, query)
 
-      response = call(:get, uri)
+      response = call(:get, uri, nil, {}, options)
 
       Serialization.block_list_from_xml(response.body)
     end

--- a/lib/azure/storage/blob/container.rb
+++ b/lib/azure/storage/blob/container.rb
@@ -44,15 +44,17 @@ module Azure::Storage::Blob
     #
     # ==== Attributes
     #
-    # * +name+          - String. The name of the container.
-    # * +options+       - Hash. Optional parameters.
+    # * +name+                      - String. The name of the container.
+    # * +options+                   - Hash. Optional parameters.
     #
     # ==== Options
     #
     # Accepted key/value pairs in options parameter are:
-    # * +:metadata+            - Hash. User defined metadata for the container (optional).
-    # * +:public_access_level+ - String. One of "container" or "blob" (optional).
-    # * +:timeout+             - Integer. A timeout in seconds.
+    # * +:metadata+                 - Hash. User defined metadata for the container (optional).
+    # * +:public_access_level+      - String. One of "container" or "blob" (optional).
+    # * +:timeout+                  - Integer. A timeout in seconds.
+    # * +:request_id+               - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+    #                                 in the analytics logs when storage analytics logging is enabled.
     #
     # See http://msdn.microsoft.com/en-us/library/azure/dd179468.aspx
     #
@@ -66,12 +68,12 @@ module Azure::Storage::Blob
       uri = container_uri(name, query)
 
       # Headers
-      headers = StorageService.service_properties_headers
+      headers = StorageService.common_headers
       StorageService.add_metadata_to_headers(options[:metadata], headers) if options[:metadata]
       headers['x-ms-blob-public-access'] = options[:public_access_level].to_s if options[:public_access_level]
 
       # Call
-      response = call(:put, uri, nil, headers)
+      response = call(:put, uri, nil, headers, options)
 
       # result
       container = Serialization.container_from_headers(response.headers)
@@ -84,13 +86,15 @@ module Azure::Storage::Blob
     #
     # ==== Attributes
     #
-    # * +name+          - String. The name of the container
-    # * +options+       - Hash. Optional parameters.
+    # * +name+                      - String. The name of the container
+    # * +options+                   - Hash. Optional parameters.
     #
     # ==== Options
     #
     # Accepted key/value pairs in options parameter are:
-    # * +:timeout+      - Integer. A timeout in seconds.
+    # * +:timeout+                  - Integer. A timeout in seconds.
+    # * +:request_id+               - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+    #                                 in the analytics logs when storage analytics logging is enabled.
     #
     # See http://msdn.microsoft.com/en-us/library/azure/dd179370.aspx
     #
@@ -101,7 +105,7 @@ module Azure::Storage::Blob
       query['timeout'] = options[:timeout].to_s if options[:timeout]
 
       # Call
-      response = call(:get, container_uri(name, query))
+      response = call(:get, container_uri(name, query), nil, {}, options)
 
       # result
       container = Serialization.container_from_headers(response.headers)
@@ -113,13 +117,15 @@ module Azure::Storage::Blob
     #
     # ==== Attributes
     #
-    # * +name+          - String. The name of the container
-    # * +options+       - Hash. Optional parameters.
+    # * +name+                      - String. The name of the container
+    # * +options+                   - Hash. Optional parameters.
     #
     # ==== Options
     #
     # Accepted key/value pairs in options parameter are:
-    # * +:timeout+      - Integer. A timeout in seconds.
+    # * +:timeout+                  - Integer. A timeout in seconds.
+    # * +:request_id+               - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+    #                                 in the analytics logs when storage analytics logging is enabled.
     #
     # See http://msdn.microsoft.com/en-us/library/azure/ee691976.aspx
     #
@@ -130,7 +136,7 @@ module Azure::Storage::Blob
       query['timeout'] = options[:timeout].to_s if options[:timeout]
 
       # Call
-      response = call(:get, container_uri(name, query))
+      response = call(:get, container_uri(name, query), nil, {}, options)
 
       # result
       container = Serialization.container_from_headers(response.headers)
@@ -142,14 +148,16 @@ module Azure::Storage::Blob
     #
     # ==== Attributes
     #
-    # * +name+          - String. The name of the container
-    # * +metadata+      - Hash. A Hash of the metadata values
-    # * +options+       - Hash. Optional parameters.
+    # * +name+                      - String. The name of the container
+    # * +metadata+                  - Hash. A Hash of the metadata values
+    # * +options+                   - Hash. Optional parameters.
     #
     # ==== Options
     #
     # Accepted key/value pairs in options parameter are:
-    # * +:timeout+      - Integer. A timeout in seconds.
+    # * +:timeout+                  - Integer. A timeout in seconds.
+    # * +:request_id+               - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+    #                                 in the analytics logs when storage analytics logging is enabled.
     #
     # See http://msdn.microsoft.com/en-us/library/azure/dd179362.aspx
     #
@@ -160,11 +168,11 @@ module Azure::Storage::Blob
       query['timeout'] = options[:timeout].to_s if options[:timeout]
 
       # Headers
-      headers = StorageService.service_properties_headers
+      headers = StorageService.common_headers
       StorageService.add_metadata_to_headers(metadata, headers) if metadata
 
       # Call
-      call(:put, container_uri(name, query), nil, headers)
+      call(:put, container_uri(name, query), nil, headers, options)
       
       # Result
       nil
@@ -175,13 +183,15 @@ module Azure::Storage::Blob
     #
     # ==== Attributes
     #
-    # * +name+          - String. The name of the container
-    # * +options+       - Hash. Optional parameters.
+    # * +name+                      - String. The name of the container
+    # * +options+                   - Hash. Optional parameters.
     #
     # ==== Options
     #
     # Accepted key/value pairs in options parameter are:
-    # * +:timeout+      - Integer. A timeout in seconds.
+    # * +:timeout+                  - Integer. A timeout in seconds.
+    # * +:request_id+               - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+    #                                 in the analytics logs when storage analytics logging is enabled.
     #
     # See http://msdn.microsoft.com/en-us/library/azure/dd179469.aspx
     #
@@ -195,7 +205,7 @@ module Azure::Storage::Blob
       query['timeout'] = options[:timeout].to_s if options[:timeout]
       
       # Call
-      response = call(:get, container_uri(name, query))
+      response = call(:get, container_uri(name, query), nil, {}, options)
 
       # Result
       container = Serialization.container_from_headers(response.headers)
@@ -220,6 +230,8 @@ module Azure::Storage::Blob
     # Accepted key/value pairs in options parameter are:
     # * +:signed_identifiers+          - Array. A list of Azure::Storage::Entity::SignedIdentifier instances (optional)
     # * +:timeout+                     - Integer. A timeout in seconds.
+    # * +:request_id+                  - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+    #                                    in the analytics logs when storage analytics logging is enabled.
     # 
     # See http://msdn.microsoft.com/en-us/library/azure/dd179391.aspx
     #
@@ -236,7 +248,7 @@ module Azure::Storage::Blob
       uri = container_uri(name, query)
 
       # Headers + body
-      headers = StorageService.service_properties_headers
+      headers = StorageService.common_headers
       headers['x-ms-blob-public-access'] = public_access_level if public_access_level && public_access_level.to_s.length > 0
 
       signed_identifiers = nil
@@ -246,7 +258,7 @@ module Azure::Storage::Blob
       body = Serialization.signed_identifiers_to_xml(signed_identifiers) if signed_identifiers
 
       # Call
-      response = call(:put, uri, body, headers)
+      response = call(:put, uri, body, headers, options)
 
       # Result
       container = Serialization.container_from_headers(response.headers)
@@ -260,13 +272,15 @@ module Azure::Storage::Blob
     #
     # ==== Attributes
     #
-    # * +name+          - String. The name of the container.
-    # * +options+       - Hash. Optional parameters.
+    # * +name+                      - String. The name of the container.
+    # * +options+                   - Hash. Optional parameters.
     #
     # ==== Options
     #
     # Accepted key/value pairs in options parameter are:
-    # * +:timeout+      - Integer. A timeout in seconds.
+    # * +:timeout+                  - Integer. A timeout in seconds.
+    # * +:request_id+               - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+    #                                 in the analytics logs when storage analytics logging is enabled.
     #
     # See http://msdn.microsoft.com/en-us/library/azure/dd179408.aspx
     #
@@ -277,7 +291,7 @@ module Azure::Storage::Blob
       query['timeout'] = options[:timeout].to_s if options[:timeout]
 
       # Call
-      call(:delete, container_uri(name, query))
+      call(:delete, container_uri(name, query), nil, {}, options)
       
       # result
       nil
@@ -299,6 +313,8 @@ module Azure::Storage::Blob
     # * +:proposed_lease_id+         - String. Proposed lease ID, in a GUID string format. The Blob service returns 400 (Invalid request)
     #                                  if the proposed lease ID is not in the correct format. (optional)
     # * +:timeout+                   - Integer. A timeout in seconds.
+    # * +:request_id+                - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+    #                                  in the analytics logs when storage analytics logging is enabled.
     # * +:if_modified_since+         - String. A DateTime value. Specify this conditional header to acquire the lease
     #                                  only if the container has been modified since the specified date/time. If the container has not been modified, 
     #                                  the Blob service returns status code 412 (Precondition Failed).
@@ -336,6 +352,8 @@ module Azure::Storage::Blob
     #
     # Accepted key/value pairs in options parameter are:
     # * +:timeout+                   - Integer. A timeout in seconds.
+    # * +:request_id+                - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+    #                                  in the analytics logs when storage analytics logging is enabled.
     # * +:if_modified_since+         - String. A DateTime value. Specify this conditional header to renew the lease
     #                                  only if the container has been modified since the specified date/time. If the container has not been modified, 
     #                                  the Blob service returns status code 412 (Precondition Failed).
@@ -369,6 +387,8 @@ module Azure::Storage::Blob
     #
     # Accepted key/value pairs in options parameter are:
     # * +:timeout+                   - Integer. A timeout in seconds.
+    # * +:request_id+                - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+    #                                  in the analytics logs when storage analytics logging is enabled.
     # * +:if_modified_since+         - String. A DateTime value. Specify this conditional header to change the lease
     #                                  only if the container has been modified since the specified date/time. If the container has not been modified, 
     #                                  the Blob service returns status code 412 (Precondition Failed).
@@ -402,6 +422,8 @@ module Azure::Storage::Blob
     #
     # Accepted key/value pairs in options parameter are:
     # * +:timeout+                   - Integer. A timeout in seconds.
+    # * +:request_id+                - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+    #                                  in the analytics logs when storage analytics logging is enabled.
     # * +:if_modified_since+         - String. A DateTime value. Specify this conditional header to release the lease
     #                                  only if the container has been modified since the specified date/time. If the container has not been modified, 
     #                                  the Blob service returns status code 412 (Precondition Failed).
@@ -447,6 +469,8 @@ module Azure::Storage::Blob
     #                                  If this option is not used, a fixed-duration lease breaks after the remaining lease
     #                                  period elapses, and an infinite lease breaks immediately.
     # * +:timeout+                   - Integer. A timeout in seconds.
+    # * +:request_id+                - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+    #                                  in the analytics logs when storage analytics logging is enabled.
     # * +:if_modified_since+         - String. A DateTime value. Specify this conditional header to break the lease
     #                                  only if the container has been modified since the specified date/time. If the container has not been modified, 
     #                                  the Blob service returns status code 412 (Precondition Failed).
@@ -508,6 +532,8 @@ module Azure::Storage::Blob
     #                         copy_blob operation should be included in the response.
     #                         (optional, Default=false)
     # * +:timeout+          - Integer. A timeout in seconds.
+    # * +:request_id+       - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+    #                         in the analytics logs when storage analytics logging is enabled.
     #
     # NOTE: Metadata requested with the :metadata parameter must have been stored in
     # accordance with the naming restrictions imposed by the 2009-09-19 version of the Blob
@@ -542,7 +568,7 @@ module Azure::Storage::Blob
       uri = container_uri(name, query)
       
       # Call
-      response = call(:get, uri)
+      response = call(:get, uri, nil, {}, options)
       
       # Result
       if response.success?

--- a/lib/azure/storage/blob/page.rb
+++ b/lib/azure/storage/blob/page.rb
@@ -53,6 +53,8 @@ module Azure::Storage
     # * +:sequence_number+           - Integer. The sequence number is a user-controlled value that you can use to track requests. 
     #                                  The value of the sequence number must be between 0 and 2^63 - 1.The default value is 0.
     # * +:timeout+                   - Integer. A timeout in seconds.
+    # * +:request_id+                - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+    #                                  in the analytics logs when storage analytics logging is enabled.
     # * +:if_modified_since+         - String. A DateTime value. Specify this conditional header to create a new blob 
     #                                  only if the blob has been modified since the specified date/time. If the blob has not been modified, 
     #                                  the Blob service returns status code 412 (Precondition Failed).
@@ -75,7 +77,7 @@ module Azure::Storage
 
       uri = blob_uri(container, blob, query)
 
-      headers = StorageService.service_properties_headers
+      headers = StorageService.common_headers
 
       # set x-ms-blob-type to PageBlob
       StorageService.with_header headers, 'x-ms-blob-type', 'PageBlob'
@@ -100,7 +102,7 @@ module Azure::Storage
       add_blob_conditional_headers options, headers
 
       # call PutBlob with empty body
-      response = call(:put, uri, nil, headers)
+      response = call(:put, uri, nil, headers, options)
 
       result = Serialization.blob_from_headers(response.headers)
       result.name = blob
@@ -141,6 +143,8 @@ module Azure::Storage
     #                                  the blob's ETag value does not match the value specified. If the values are identical, 
     #                                  the Blob service returns status code 412 (Precondition Failed).
     # * +:timeout+                   - Integer. A timeout in seconds.
+    # * +:request_id+                - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+    #                                  in the analytics logs when storage analytics logging is enabled.
     # 
     # See http://msdn.microsoft.com/en-us/library/azure/ee691975.aspx
     #
@@ -150,7 +154,7 @@ module Azure::Storage
       StorageService.with_query query, 'timeout', options[:timeout].to_s if options[:timeout]
 
       uri = blob_uri(container, blob, query)
-      headers = StorageService.service_properties_headers
+      headers = StorageService.common_headers
       StorageService.with_header headers, 'x-ms-range', "bytes=#{start_range}-#{end_range}"
       StorageService.with_header headers, 'x-ms-page-write', 'update'
 
@@ -162,7 +166,7 @@ module Azure::Storage
         add_blob_conditional_headers options, headers
       end
 
-      response = call(:put, uri, content, headers)
+      response = call(:put, uri, content, headers, options)
 
       result = Serialization.blob_from_headers(response.headers)
       result.name = blob
@@ -184,6 +188,8 @@ module Azure::Storage
     #
     # Accepted key/value pairs in options parameter are:
     # * +:timeout+                   - Integer. A timeout in seconds.
+    # * +:request_id+                - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+    #                                  in the analytics logs when storage analytics logging is enabled.
     # * +:if_modified_since+         - String. A DateTime value. Specify this conditional header to clear the page only if 
     #                                  the blob has been modified since the specified date/time. If the blob has not been modified, 
     #                                  the Blob service returns status code 412 (Precondition Failed).
@@ -206,7 +212,7 @@ module Azure::Storage
 
       uri = blob_uri(container, blob, query)
 
-      headers = StorageService.service_properties_headers
+      headers = StorageService.common_headers
       StorageService.with_header headers, 'x-ms-range', "bytes=#{start_range}-#{end_range}"
       StorageService.with_header headers, 'x-ms-page-write', 'clear'
 
@@ -218,7 +224,7 @@ module Azure::Storage
         add_blob_conditional_headers options, headers
       end
 
-      response = call(:put, uri, nil, headers)
+      response = call(:put, uri, nil, headers, options)
 
       result = Serialization.blob_from_headers(response.headers)
       result.name = blob
@@ -243,6 +249,8 @@ module Azure::Storage
     # * +:snapshot+                  - String. An opaque DateTime value that specifies the blob snapshot to
     #                                  retrieve information from. (optional)
     # * +:timeout+                   - Integer. A timeout in seconds.
+    # * +:request_id+                - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+    #                                  in the analytics logs when storage analytics logging is enabled.
      # * +:if_modified_since+        - String. A DateTime value. Specify this conditional header to list the pages only if 
     #                                  the blob has been modified since the specified date/time. If the blob has not been modified, 
     #                                  the Blob service returns status code 412 (Precondition Failed).
@@ -271,11 +279,11 @@ module Azure::Storage
 
       options[:start_range] = 0 if options[:end_range] and not options[:start_range]
 
-      headers = StorageService.service_properties_headers
+      headers = StorageService.common_headers
       StorageService.with_header headers, 'x-ms-range', "bytes=#{options[:start_range]}-#{options[:end_range]}" if options[:start_range]
       add_blob_conditional_headers options, headers
       
-      response = call(:get, uri, nil, headers)
+      response = call(:get, uri, nil, headers, options)
 
       pagelist = Serialization.page_list_from_xml(response.body)
       pagelist
@@ -296,6 +304,8 @@ module Azure::Storage
     #
     # Accepted key/value pairs in options parameter are:
     # * +:timeout+                   - Integer. A timeout in seconds.
+    # * +:request_id+                - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+    #                                  in the analytics logs when storage analytics logging is enabled.
     # * +:if_modified_since+         - String. A DateTime value. Specify this conditional header to set the blob properties
     #                                  only if the blob has been modified since the specified date/time. If the blob has not been modified, 
     #                                  the Blob service returns status code 412 (Precondition Failed).
@@ -356,6 +366,8 @@ module Azure::Storage
     #
     # Accepted key/value pairs in options parameter are:
     # * +:timeout+                   - Integer. A timeout in seconds.
+    # * +:request_id+                - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+    #                                  in the analytics logs when storage analytics logging is enabled.
     # * +:if_modified_since+         - String. A DateTime value. Specify this conditional header to set the blob properties
     #                                  only if the blob has been modified since the specified date/time. If the blob has not been modified, 
     #                                  the Blob service returns status code 412 (Precondition Failed).

--- a/lib/azure/storage/core/filter/retry_filter.rb
+++ b/lib/azure/storage/core/filter/retry_filter.rb
@@ -79,20 +79,26 @@ module Azure::Storage::Core::Filter
         retry_data[:retryable] = true;
         return true
       end
+
+      error_message = retry_data[:error].inspect
       
-      if retry_data[:error].inspect.include?('SocketError: Hostname not known')
+      if error_message.include?('SocketError: Hostname not known')
         # Retry on local DNS resolving
         # When uses resolv-replace.rb to replace the libc resolver 
         # Reference: 
         #  https://makandracards.com/ninjaconcept/30815-fixing-socketerror-getaddrinfo-name-or-service-not-known-with-ruby-s-resolv-replace-rb 
         #  http://www.subelsky.com/2014/05/fixing-socketerror-getaddrinfo-name-or.html 
         retry_data[:retryable] = true;
-      elsif retry_data[:error].inspect.include?('getaddrinfo: Name or service not known')
+      elsif error_message.include?('getaddrinfo: Name or service not known')
         # When uses the default resolver 
         retry_data[:retryable] = true;
-      elsif retry_data[:error].inspect.include?('Errno::EACCES')
+      elsif error_message.downcase.include?('timeout')
+        retry_data[:retryable] = true;
+      elsif error_message.include?('Errno::ECONNRESET')
+        retry_data[:retryable] = true;
+      elsif error_message.include?('Errno::EACCES')
         retry_data[:retryable] = false;
-      elsif retry_data[:error].inspect.include?('NOSUPPORT')
+      elsif error_message.include?('NOSUPPORT')
         retry_data[:retryable] = false;
       end
       

--- a/lib/azure/storage/queue/queue_service.rb
+++ b/lib/azure/storage/queue/queue_service.rb
@@ -41,27 +41,29 @@ module Azure::Storage
       #
       # ==== Attributes
       #
-      # * +options+    - Hash. Optional parameters.
+      # * +options+                    - Hash. Optional parameters.
       #
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
-      # * +:prefix+      - String. Filters the results to return only containers 
-      #   whose name begins with the specified prefix. (optional)
-      # * +:marker+      - String. An identifier the specifies the portion of the 
-      #   list to be returned. This value comes from the property
-      #   Azure::Service::EnumerationResults.continuation_token when there 
-      #   are more containers available than were returned. The 
-      #   marker value may then be used here to request the next set
-      #   of list items. (optional)
-      # * +:max_results+ - Integer. Specifies the maximum number of containers to return. 
-      #   If max_results is not specified, or is a value greater than 
-      #   5,000, the server will return up to 5,000 items. If it is set 
-      #   to a value less than or equal to zero, the server will return 
-      #   status code 400 (Bad Request). (optional)
-      # * +:metadata+    - Boolean. Specifies whether or not to return the container metadata.
-      #   (optional, Default=false)
-      # * +:timeout+     - Integer. A timeout in seconds.
+      # * +:prefix+                    - String. Filters the results to return only containers 
+      #                                  whose name begins with the specified prefix. (optional)
+      # * +:marker+                    - String. An identifier the specifies the portion of the 
+      #                                  list to be returned. This value comes from the property
+      #                                  Azure::Service::EnumerationResults.continuation_token when there 
+      #                                  are more containers available than were returned. The 
+      #                                  marker value may then be used here to request the next set
+      #                                  of list items. (optional)
+      # * +:max_results+               - Integer. Specifies the maximum number of containers to return. 
+      #                                  If max_results is not specified, or is a value greater than 
+      #                                  5,000, the server will return up to 5,000 items. If it is set 
+      #                                  to a value less than or equal to zero, the server will return 
+      #                                  status code 400 (Bad Request). (optional)
+      # * +:metadata+                  - Boolean. Specifies whether or not to return the container metadata.
+      #                                  (optional, Default=false)
+      # * +:timeout+                   - Integer. A timeout in seconds.
+      # * +:request_id+                - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+      #                                  in the analytics logs when storage analytics logging is enabled.
       #
       # NOTE: Metadata requested with the :metadata parameter must have been stored in
       # accordance with the naming restrictions imposed by the 2009-09-19 version of the queue 
@@ -84,7 +86,7 @@ module Azure::Storage
         query["timeout"] = options[:timeout].to_s if options[:timeout]
 
         uri = collection_uri(query)
-        response = call(:get, uri)
+        response = call(:get, uri, nil, {}, options)
 
         Serialization.queue_enumeration_results_from_xml(response.body)
       end
@@ -100,13 +102,15 @@ module Azure::Storage
       # 
       # ==== Attributes
       #
-      # * +queue_name+ - String. The name of the queue.
-      # * +options+    - Hash. Optional parameters.
+      # * +queue_name+                 - String. The name of the queue.
+      # * +options+                    - Hash. Optional parameters.
       #
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
-      # * +:timeout+   - Integer. A timeout in seconds.
+      # * +:timeout+                   - Integer. A timeout in seconds.
+      # * +:request_id+                - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+      #                                  in the analytics logs when storage analytics logging is enabled.
       # 
       # See http://msdn.microsoft.com/en-us/library/azure/dd179454
       # 
@@ -115,7 +119,7 @@ module Azure::Storage
         query = { }
         query["timeout"] = options[:timeout].to_s if options[:timeout]
         uri = messages_uri(queue_name, query)
-        call(:delete, uri)
+        call(:delete, uri, nil, {}, options)
         nil
       end
     
@@ -123,14 +127,16 @@ module Azure::Storage
       # 
       # ==== Attributes
       #
-      # * +queue_name+     - String. The queue name.
-      # * +options+        - Hash. Optional parameters. 
+      # * +queue_name+                 - String. The queue name.
+      # * +options+                    - Hash. Optional parameters. 
       #
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
-      # * +:metadata+      - Hash. A hash of user defined metadata.
-      # * +:timeout+       - Integer. A timeout in seconds.
+      # * +:metadata+                  - Hash. A hash of user defined metadata.
+      # * +:timeout+                   - Integer. A timeout in seconds.
+      # * +:request_id+                - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+      #                                  in the analytics logs when storage analytics logging is enabled.
       #
       # See http://msdn.microsoft.com/en-us/library/azure/dd179342
       #
@@ -144,7 +150,7 @@ module Azure::Storage
         headers = { }
         Service::StorageService.add_metadata_to_headers(options[:metadata] || {}, headers) if options[:metadata]
 
-        call(:put, uri, nil, headers)
+        call(:put, uri, nil, headers, options)
         nil
       end
 
@@ -152,13 +158,15 @@ module Azure::Storage
       # 
       # ==== Attributes
       #
-      # * +queue_name+     - String. The queue name.
-      # * +options+        - Hash. Optional parameters. 
+      # * +queue_name+                 - String. The queue name.
+      # * +options+                    - Hash. Optional parameters. 
       #
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
-      # * +:timeout+       - Integer. A timeout in seconds.
+      # * +:timeout+                   - Integer. A timeout in seconds.
+      # * +:request_id+                - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+      #                                  in the analytics logs when storage analytics logging is enabled.
       #
       # See http://msdn.microsoft.com/en-us/library/azure/dd179436
       #
@@ -169,7 +177,7 @@ module Azure::Storage
 
         uri = queue_uri(queue_name, query)
 
-        call(:delete, uri)
+        call(:delete, uri, nil, {}, options)
         nil
       end
 
@@ -177,13 +185,15 @@ module Azure::Storage
       # 
       # ==== Attributes
       #
-      # * +queue_name+     - String. The queue name.
-      # * +options+        - Hash. Optional parameters. 
+      # * +queue_name+                 - String. The queue name.
+      # * +options+                    - Hash. Optional parameters. 
       #
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
-      # * +:timeout+       - Integer. A timeout in seconds.
+      # * +:timeout+                   - Integer. A timeout in seconds.
+      # * +:request_id+                - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+      #                                  in the analytics logs when storage analytics logging is enabled.
       #
       # See http://msdn.microsoft.com/en-us/library/azure/dd179384
       #
@@ -198,7 +208,7 @@ module Azure::Storage
 
         uri = queue_uri(queue_name, query)
 
-        response = call(:get, uri)
+        response = call(:get, uri, nil, {}, options)
 
         approximate_messages_count = response.headers["x-ms-approximate-messages-count"]
         metadata = Serialization.metadata_from_headers(response.headers)
@@ -211,14 +221,16 @@ module Azure::Storage
       # 
       # ==== Attributes
       #
-      # * +queue_name+ - String. The queue name.
-      # * +metadata+   - Hash. A hash of user defined metadata
-      # * +options+    - Hash. Optional parameters. 
+      # * +queue_name+                 - String. The queue name.
+      # * +metadata+                   - Hash. A hash of user defined metadata
+      # * +options+                    - Hash. Optional parameters. 
       #
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
-      # * +:timeout+       - Integer. A timeout in seconds.
+      # * +:timeout+                   - Integer. A timeout in seconds.
+      # * +:request_id+                - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+      #                                  in the analytics logs when storage analytics logging is enabled.
       #
       # See http://msdn.microsoft.com/en-us/library/azure/dd179348
       #
@@ -232,7 +244,7 @@ module Azure::Storage
         headers ={}
         Service::StorageService.add_metadata_to_headers(metadata || {}, headers)
 
-        call(:put, uri, nil, headers)
+        call(:put, uri, nil, headers, options)
         nil
       end
 
@@ -240,13 +252,15 @@ module Azure::Storage
       #
       # ==== Attributes
       #
-      # * +queue_name+ - String. The queue name.
-      # * +options+    - Hash. Optional parameters. 
+      # * +queue_name+                 - String. The queue name.
+      # * +options+                    - Hash. Optional parameters. 
       #
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
-      # * +:timeout+       - Integer. A timeout in seconds.
+      # * +:timeout+                   - Integer. A timeout in seconds.
+      # * +:request_id+                - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+      #                                  in the analytics logs when storage analytics logging is enabled.
       #
       # See http://msdn.microsoft.com/en-us/library/azure/jj159101
       #
@@ -255,7 +269,7 @@ module Azure::Storage
         query = { "comp" => "acl" }
         query["timeout"] = options[:timeout].to_s if options[:timeout]
 
-        response = call(:get, queue_uri(queue_name, query))
+        response = call(:get, queue_uri(queue_name, query), nil, {}, options)
 
         signed_identifiers = []
         signed_identifiers = Serialization.signed_identifiers_from_xml(response.body) unless response.body == nil or response.body.length < 1
@@ -266,14 +280,16 @@ module Azure::Storage
       #
       # ==== Attributes
       #
-      # * +queue_name+ - String. The queue name.
-      # * +options+    - Hash. Optional parameters. 
+      # * +queue_name+                 - String. The queue name.
+      # * +options+                    - Hash. Optional parameters. 
       #
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
-      # * +:signed_identifiers+  - Array. A list of Azure::Storage::Entity::SignedIdentifier instances 
-      # * +:timeout+             - Integer. A timeout in seconds.
+      # * +:signed_identifiers+        - Array. A list of Azure::Storage::Entity::SignedIdentifier instances 
+      # * +:timeout+                   - Integer. A timeout in seconds.
+      # * +:request_id+                - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+      #                                  in the analytics logs when storage analytics logging is enabled.
       # 
       # See http://msdn.microsoft.com/en-us/library/azure/jj159099
       #
@@ -286,7 +302,7 @@ module Azure::Storage
         body = nil
         body = Serialization.signed_identifiers_to_xml(options[:signed_identifiers]) if options[:signed_identifiers] && options[:signed_identifiers].length > 0
 
-        call(:put, uri, body, {})
+        call(:put, uri, body, {}, options)
         nil
       end
 
@@ -301,15 +317,17 @@ module Azure::Storage
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
-      # * +:visibility_timeout+     - Integer. Specifies the new visibility timeout value, in seconds, relative to server 
-      #   time. The new value must be larger than or equal to 0, and cannot be larger than 7 
-      #   days. The visibility timeout of a message cannot be set to a value later than the 
-      #   expiry time. :visibility_timeout should be set to a value smaller than the 
-      #   time-to-live value. If not specified, the default value is 0.
-      # * +:message_ttl+            - Integer. Specifies the time-to-live interval for the message, in seconds. The maximum 
-      #   time-to-live allowed is 7 days. If not specified, the default time-to-live is 7 days.
-      # * +:encode+                 - Boolean. If set to true, the message will be base64 encoded.
-      # * +:timeout+                - Integer. A timeout in seconds.
+      # * +:visibility_timeout+        - Integer. Specifies the new visibility timeout value, in seconds, relative to server 
+      #                                  time. The new value must be larger than or equal to 0, and cannot be larger than 7 
+      #                                  days. The visibility timeout of a message cannot be set to a value later than the 
+      #                                  expiry time. :visibility_timeout should be set to a value smaller than the 
+      #                                  time-to-live value. If not specified, the default value is 0.
+      # * +:message_ttl+               - Integer. Specifies the time-to-live interval for the message, in seconds. The maximum 
+      #                                  time-to-live allowed is 7 days. If not specified, the default time-to-live is 7 days.
+      # * +:encode+                    - Boolean. If set to true, the message will be base64 encoded.
+      # * +:timeout+                   - Integer. A timeout in seconds.
+      # * +:request_id+                - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+      #                                  in the analytics logs when storage analytics logging is enabled.
       #
       # See http://msdn.microsoft.com/en-us/library/azure/dd179346
       #
@@ -326,7 +344,7 @@ module Azure::Storage
         uri = messages_uri(queue_name, query)
         body = Serialization.message_to_xml(message_text, options[:encode])
 
-        call(:post, uri, body, {})
+        call(:post, uri, body, {}, options)
         nil
       end
 
@@ -334,16 +352,18 @@ module Azure::Storage
       # 
       # ==== Attributes
       #
-      # * +queue_name+   - String. The queue name.
-      # * +message_id+   - String. The id of the message.
-      # * +pop_receipt+  - String. The valid pop receipt value returned from an earlier call to the Get Messages or 
-      #   Update Message operation.
-      # * +options+      - Hash. Optional parameters. 
+      # * +queue_name+                 - String. The queue name.
+      # * +message_id+                 - String. The id of the message.
+      # * +pop_receipt+                - String. The valid pop receipt value returned from an earlier call to the Get Messages or 
+      #                                  Update Message operation.
+      # * +options+                    - Hash. Optional parameters. 
       #
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
-      # * +:timeout+     - Integer. A timeout in seconds.
+      # * +:timeout+                   - Integer. A timeout in seconds.
+      # * +:request_id+                - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+      #                                  in the analytics logs when storage analytics logging is enabled.
       # 
       # See http://msdn.microsoft.com/en-us/library/azure/dd179347
       #
@@ -392,7 +412,7 @@ module Azure::Storage
 
         uri = message_uri(queue_name, message_id, query)
 
-        call(:delete, uri)
+        call(:delete, uri, nil, {}, options)
         nil
       end
 
@@ -400,15 +420,17 @@ module Azure::Storage
       #
       # ==== Attributes
       #
-      # * +queue_name+   - String. The queue name.
-      # * +options+      - Hash. Optional parameters. 
+      # * +queue_name+                 - String. The queue name.
+      # * +options+                    - Hash. Optional parameters. 
       #
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
-      # * +:number_of_messages+ - Integer. How many messages to return. (optional, Default: 1)
-      # * +:decode+             - Boolean. Boolean value indicating if the message should be base64 decoded.
-      # * +:timeout+            - Integer. A timeout in seconds.
+      # * +:number_of_messages+        - Integer. How many messages to return. (optional, Default: 1)
+      # * +:decode+                    - Boolean. Boolean value indicating if the message should be base64 decoded.
+      # * +:timeout+                   - Integer. A timeout in seconds.
+      # * +:request_id+                - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+      #                                  in the analytics logs when storage analytics logging is enabled.
       #
       # See http://msdn.microsoft.com/en-us/library/azure/dd179472
       #
@@ -421,7 +443,7 @@ module Azure::Storage
         query["timeout"] = options[:timeout].to_s if options[:timeout]
 
         uri = messages_uri(queue_name, query)
-        response = call(:get, uri)
+        response = call(:get, uri, nil, {}, options)
 
         messages = Serialization.queue_messages_from_xml(response.body, options[:decode])
         messages
@@ -431,16 +453,18 @@ module Azure::Storage
       #
       # ==== Attributes
       #
-      # * +queue_name+          - String. The queue name.
-      # * +visibility_timeout+  - Integer. The new visibility timeout value, in seconds, relative to server time.
-      # * +options+             - Hash. Optional parameters. 
+      # * +queue_name+                 - String. The queue name.
+      # * +visibility_timeout+         - Integer. The new visibility timeout value, in seconds, relative to server time.
+      # * +options+                    - Hash. Optional parameters. 
       #
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
-      # * +:number_of_messages+ - Integer. How many messages to return. (optional, Default: 1)
-      # * +:timeout+            - Integer. A timeout in seconds.
-      # * +:decode+             - Boolean. Boolean value indicating if the message should be base64 decoded.
+      # * +:number_of_messages+        - Integer. How many messages to return. (optional, Default: 1)
+      # * +:timeout+                   - Integer. A timeout in seconds.
+      # * +:request_id+                - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+      #                                  in the analytics logs when storage analytics logging is enabled.
+      # * +:decode+                    - Boolean. Boolean value indicating if the message should be base64 decoded.
       #
       # See http://msdn.microsoft.com/en-us/library/azure/dd179474
       #
@@ -453,7 +477,7 @@ module Azure::Storage
         query["timeout"] = options[:timeout].to_s if options[:timeout]
 
         uri = messages_uri(queue_name, query)
-        response = call(:get, uri)
+        response = call(:get, uri, nil, {}, options)
 
         messages = Serialization.queue_messages_from_xml(response.body, options[:decode])
         messages
@@ -463,20 +487,22 @@ module Azure::Storage
       # 
       # ==== Attributes
       #
-      # * +queue_name+         - String. The queue name.
-      # * +message_id+         - String. The id of the message.
-      # * +pop_receipt+        - String. The valid pop receipt value returned from an earlier call to the Get Messages or 
-      #   update Message operation.
-      # * +message_text+       - String. The message contents. Note that the message content must be in a format that may 
-      #   be encoded with UTF-8.
-      # * +visibility_timeout+ - Integer. The new visibility timeout value, in seconds, relative to server time.
-      # * +options+            - Hash. Optional parameters. 
+      # * +queue_name+                 - String. The queue name.
+      # * +message_id+                 - String. The id of the message.
+      # * +pop_receipt+                - String. The valid pop receipt value returned from an earlier call to the Get Messages or 
+      #                                  update Message operation.
+      # * +message_text+               - String. The message contents. Note that the message content must be in a format that may 
+      #                                  be encoded with UTF-8.
+      # * +visibility_timeout+         - Integer. The new visibility timeout value, in seconds, relative to server time.
+      # * +options+                    - Hash. Optional parameters. 
       #
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
-      # * +:encode+                 - Boolean. If set to true, the message will be base64 encoded.
-      # * +:timeout+           - Integer. A timeout in seconds.
+      # * +:encode+                    - Boolean. If set to true, the message will be base64 encoded.
+      # * +:timeout+                   - Integer. A timeout in seconds.
+      # * +:request_id+                - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+      #                                  in the analytics logs when storage analytics logging is enabled.
       #
       # See http://msdn.microsoft.com/en-us/library/azure/hh452234
       #
@@ -517,7 +543,7 @@ module Azure::Storage
         uri = message_uri(queue_name, message_id, query)
         body = Serialization.message_to_xml(message_text, options[:encode])
 
-        response = call(:put, uri, body, {})
+        response = call(:put, uri, body, {}, options)
         new_pop_receipt = response.headers["x-ms-popreceipt"]
         time_next_visible = response.headers["x-ms-time-next-visible"]
         return new_pop_receipt, time_next_visible

--- a/lib/azure/storage/table/table_service.rb
+++ b/lib/azure/storage/table/table_service.rb
@@ -42,14 +42,16 @@ module Azure::Storage
       #
       # ==== Attributes
       #
-      # * +table_name+ - String. The table name
-      # * +options+    - Hash. Optional parameters. 
+      # * +table_name+               - String. The table name
+      # * +options+                  - Hash. Optional parameters. 
       #
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
       #
-      # * +:timeout+   - Integer. A timeout in seconds.
+      # * +:timeout+                 - Integer. A timeout in seconds.
+      # * +:request_id+              - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+      #                                in the analytics logs when storage analytics logging is enabled.
       #
       # See http://msdn.microsoft.com/en-us/library/azure/dd135729
       #
@@ -59,7 +61,7 @@ module Azure::Storage
         query['timeout'] = options[:timeout].to_s if options[:timeout]
 
         body = Table::Serialization.hash_to_entry_xml({"TableName" => table_name}).to_xml
-        call(:post, collection_uri(query), body)
+        call(:post, collection_uri(query), body, {}, options)
         nil
       end
 
@@ -67,13 +69,15 @@ module Azure::Storage
       #
       # ==== Attributes
       #
-      # * +table_name+ - String. The table name
-      # * +options+    - Hash. Optional parameters. 
+      # * +table_name+               - String. The table name
+      # * +options+                  - Hash. Optional parameters. 
       #
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
-      # * +:timeout+   - Integer. A timeout in seconds.
+      # * +:timeout+                 - Integer. A timeout in seconds.
+      # * +:request_id+              - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+      #                                in the analytics logs when storage analytics logging is enabled.
       #
       # See http://msdn.microsoft.com/en-us/library/azure/dd179387
       #
@@ -82,7 +86,7 @@ module Azure::Storage
         query = { }
         query["timeout"] = options[:timeout].to_s if options[:timeout]
 
-        call(:delete, table_uri(table_name, query))
+        call(:delete, table_uri(table_name, query), nil, {}, options)
         nil
       end
 
@@ -90,20 +94,22 @@ module Azure::Storage
       #
       # ==== Attributes
       #
-      # * +table_name+ - String. The table name
-      # * +options+    - Hash. Optional parameters. 
+      # * +table_name+               - String. The table name
+      # * +options+                  - Hash. Optional parameters. 
       #
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
-      # * +:timeout+   - Integer. A timeout in seconds.
+      # * +:timeout+                 - Integer. A timeout in seconds.
+      # * +:request_id+              - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+      #                                in the analytics logs when storage analytics logging is enabled.
       #
       # Returns the last updated time for the table
       def get_table(table_name, options={})
         query = { }
         query["timeout"] = options[:timeout].to_s if options[:timeout]
 
-        response = call(:get, table_uri(table_name, query))
+        response = call(:get, table_uri(table_name, query), nil, {}, options)
         results = Table::Serialization.hash_from_entry_xml(response.body)
         results[:updated]
       rescue => e
@@ -114,14 +120,16 @@ module Azure::Storage
       #
       # ==== Attributes
       #
-      # * +options+    - Hash. Optional parameters. 
+      # * +options+                  - Hash. Optional parameters. 
       #
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
-      # * +:next_table_token+   - String. A token used to enumerate the next page of results, when the list of tables is
-      #   larger than a single operation can return at once. (optional)
-      # * +:timeout+            - Integer. A timeout in seconds.
+      # * +:next_table_token+        - String. A token used to enumerate the next page of results, when the list of tables is
+      #                                larger than a single operation can return at once. (optional)
+      # * +:timeout+                 - Integer. A timeout in seconds.
+      # * +:request_id+              - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+      #                                in the analytics logs when storage analytics logging is enabled.
       #
       # See http://msdn.microsoft.com/en-us/library/azure/dd179405
       #
@@ -132,7 +140,7 @@ module Azure::Storage
         query["timeout"] = options[:timeout].to_s if options[:timeout]
         uri = collection_uri(query)
 
-        response = call(:get, uri)
+        response = call(:get, uri, nil, {}, options)
         entries = Table::Serialization.entries_from_feed_xml(response.body) || []
 
         values = Azure::Service::EnumerationResults.new(entries)
@@ -146,13 +154,15 @@ module Azure::Storage
       #
       # ==== Attributes
       #
-      # * +table_name+ - String. The table name
-      # * +options+    - Hash. Optional parameters. 
+      # * +table_name+               - String. The table name
+      # * +options+                  - Hash. Optional parameters. 
       #
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
-      # * +:timeout+   - Integer. A timeout in seconds.
+      # * +:timeout+                 - Integer. A timeout in seconds.
+      # * +:request_id+              - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+      #                                in the analytics logs when storage analytics logging is enabled.
       #
       # See http://msdn.microsoft.com/en-us/library/azure/jj159100
       #
@@ -161,7 +171,7 @@ module Azure::Storage
         query = { 'comp' => 'acl'}
         query['timeout'] = options[:timeout].to_s if options[:timeout]
 
-        response = call(:get, generate_uri(table_name, query), nil, {'x-ms-version' => '2012-02-12'})
+        response = call(:get, generate_uri(table_name, query), nil, {'x-ms-version' => '2012-02-12'}, options)
 
         signed_identifiers = []
         signed_identifiers = Table::Serialization.signed_identifiers_from_xml response.body unless response.body == nil or response.body.length < 1
@@ -174,14 +184,16 @@ module Azure::Storage
       #
       # ==== Attributes
       #
-      # * +table_name+ - String. The table name
-      # * +options+    - Hash. Optional parameters. 
+      # * +table_name+               - String. The table name
+      # * +options+                  - Hash. Optional parameters. 
       #
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
-      # * +:signed_identifiers+  - Array. A list of Azure::Storage::Entity::SignedIdentifier instances
-      # * +:timeout+             - Integer. A timeout in seconds.
+      # * +:signed_identifiers+      - Array. A list of Azure::Storage::Entity::SignedIdentifier instances
+      # * +:timeout+                 - Integer. A timeout in seconds.
+      # * +:request_id+              - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+      #                                in the analytics logs when storage analytics logging is enabled.
       # 
       # See http://msdn.microsoft.com/en-us/library/azure/jj159102
       #
@@ -194,7 +206,7 @@ module Azure::Storage
         body = nil
         body = Table::Serialization.signed_identifiers_to_xml options[:signed_identifiers] if options[:signed_identifiers] && options[:signed_identifiers].length > 0
 
-        call(:put, uri, body, {'x-ms-version' => '2012-02-12'})
+        call(:put, uri, body, {'x-ms-version' => '2012-02-12'}, options)
         nil
       end
 
@@ -203,14 +215,16 @@ module Azure::Storage
       #
       # ==== Attributes
       #
-      # * +table_name+    - String. The table name
-      # * +entity_values+ - Hash. A hash of the name/value pairs for the entity. 
-      # * +options+       - Hash. Optional parameters. 
+      # * +table_name+               - String. The table name
+      # * +entity_values+            - Hash. A hash of the name/value pairs for the entity. 
+      # * +options+                  - Hash. Optional parameters. 
       #
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
-      # * +:timeout+      - Integer. A timeout in seconds.
+      # * +:timeout+                 - Integer. A timeout in seconds.
+      # * +:request_id+              - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+      #                                in the analytics logs when storage analytics logging is enabled.
       #
       # See http://msdn.microsoft.com/en-us/library/azure/dd179433
       #
@@ -221,7 +235,7 @@ module Azure::Storage
         query = { }
         query['timeout'] = options[:timeout].to_s if options[:timeout]
 
-        response = call(:post, entities_uri(table_name, nil, nil, query), body)
+        response = call(:post, entities_uri(table_name, nil, nil, query), body, {}, options)
         
         result = Table::Serialization.hash_from_entry_xml(response.body)
 
@@ -239,19 +253,21 @@ module Azure::Storage
       #
       # ==== Attributes
       #
-      # * +table_name+    - String. The table name
-      # * +options+       - Hash. Optional parameters. 
+      # * +table_name+               - String. The table name
+      # * +options+                  - Hash. Optional parameters. 
       #
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
-      # * +:partition_key+      - String. The partition key (optional)
-      # * +:row_key+            - String. The row key (optional)
-      # * +:select+             - Array. An array of property names to return (optional)
-      # * +:filter+             - String. A filter expression (optional)
-      # * +:top+                - Integer. A limit for the number of results returned (optional)
-      # * +:continuation_token+ - Hash. The continuation token.
-      # * +:timeout+            - Integer. A timeout in seconds.
+      # * +:partition_key+           - String. The partition key (optional)
+      # * +:row_key+                 - String. The row key (optional)
+      # * +:select+                  - Array. An array of property names to return (optional)
+      # * +:filter+                  - String. A filter expression (optional)
+      # * +:top+                     - Integer. A limit for the number of results returned (optional)
+      # * +:continuation_token+      - Hash. The continuation token.
+      # * +:timeout+                 - Integer. A timeout in seconds.
+      # * +:request_id+              - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+      #                                in the analytics logs when storage analytics logging is enabled.
       #
       # See http://msdn.microsoft.com/en-us/library/azure/dd179421
       #
@@ -266,7 +282,7 @@ module Azure::Storage
         query["timeout"] = options[:timeout].to_s if options[:timeout]
 
         uri = entities_uri(table_name, options[:partition_key], options[:row_key], query)
-        response = call(:get, uri, nil, { "DataServiceVersion" => "2.0;NetFx"})
+        response = call(:get, uri, nil, {"DataServiceVersion" => "2.0;NetFx"}, options)
 
         entities = Azure::Service::EnumerationResults.new
 
@@ -298,17 +314,19 @@ module Azure::Storage
       #
       # ==== Attributes
       #
-      # * +table_name+    - String. The table name
-      # * +entity_values+ - Hash. A hash of the name/value pairs for the entity.
-      # * +options+       - Hash. Optional parameters. 
+      # * +table_name+               - String. The table name
+      # * +entity_values+            - Hash. A hash of the name/value pairs for the entity.
+      # * +options+                  - Hash. Optional parameters. 
       #
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
-      # * +:if_match+              - String. A matching condition which is required for update (optional, Default="*")
-      # * +:create_if_not_exists+  - Boolean. If true, and partition_key and row_key do not reference and existing entity, 
-      #   that entity will be inserted. If false, the operation will fail. (optional, Default=false)
-      # * +:timeout+               - Integer. A timeout in seconds.
+      # * +:if_match+                - String. A matching condition which is required for update (optional, Default="*")
+      # * +:create_if_not_exists+    - Boolean. If true, and partition_key and row_key do not reference and existing entity, 
+      #                                that entity will be inserted. If false, the operation will fail. (optional, Default=false)
+      # * +:timeout+                 - Integer. A timeout in seconds.
+      # * +:request_id+              - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+      #                                in the analytics logs when storage analytics logging is enabled.
       #
       # See http://msdn.microsoft.com/en-us/library/azure/dd179427
       #
@@ -329,7 +347,7 @@ module Azure::Storage
 
         body = Table::Serialization.hash_to_entry_xml(entity_values).to_xml
 
-        response = call(:put, uri, body, headers)
+        response = call(:put, uri, body, headers, options)
         response.headers["etag"]
       rescue => e
         raise_with_response(e, response)
@@ -340,17 +358,19 @@ module Azure::Storage
       #
       # ==== Attributes
       #
-      # * +table_name+    - String. The table name
-      # * +entity_values+ - Hash. A hash of the name/value pairs for the entity.
-      # * +options+       - Hash. Optional parameters. 
+      # * +table_name+               - String. The table name
+      # * +entity_values+            - Hash. A hash of the name/value pairs for the entity.
+      # * +options+                  - Hash. Optional parameters. 
       #
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
-      # * +:if_match+              - String. A matching condition which is required for update (optional, Default="*")
-      # * +:create_if_not_exists+  - Boolean. If true, and partition_key and row_key do not reference and existing entity, 
-      #   that entity will be inserted. If false, the operation will fail. (optional, Default=false)
-      # * +:timeout+               - Integer. A timeout in seconds.
+      # * +:if_match+                - String. A matching condition which is required for update (optional, Default="*")
+      # * +:create_if_not_exists+    - Boolean. If true, and partition_key and row_key do not reference and existing entity, 
+      #                                that entity will be inserted. If false, the operation will fail. (optional, Default=false)
+      # * +:timeout+                 - Integer. A timeout in seconds.
+      # * +:request_id+              - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+      #                                in the analytics logs when storage analytics logging is enabled.
       # 
       # See http://msdn.microsoft.com/en-us/library/azure/dd179392
       # 
@@ -371,7 +391,7 @@ module Azure::Storage
 
         body = Table::Serialization.hash_to_entry_xml(entity_values).to_xml
 
-        response = call(:post, uri, body, headers)
+        response = call(:post, uri, body, headers, options)
         response.headers["etag"]
       rescue => e
         raise_with_response(e, response)
@@ -381,14 +401,16 @@ module Azure::Storage
       #
       # ==== Attributes
       #
-      # * +table_name+    - String. The table name
-      # * +entity_values+ - Hash. A hash of the name/value pairs for the entity.
-      # * +options+       - Hash. Optional parameters. 
+      # * +table_name+               - String. The table name
+      # * +entity_values+            - Hash. A hash of the name/value pairs for the entity.
+      # * +options+                  - Hash. Optional parameters. 
       #
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
-      # * +:timeout+      - Integer. A timeout in seconds.
+      # * +:timeout+                 - Integer. A timeout in seconds.
+      # * +:request_id+              - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+      #                                in the analytics logs when storage analytics logging is enabled.
       # 
       # See http://msdn.microsoft.com/en-us/library/azure/hh452241
       # 
@@ -402,14 +424,16 @@ module Azure::Storage
       #
       # ==== Attributes
       #
-      # * +table_name+    - String. The table name
-      # * +entity_values+ - Hash. A hash of the name/value pairs for the entity.
-      # * +options+       - Hash. Optional parameters. 
+      # * +table_name+               - String. The table name
+      # * +entity_values+            - Hash. A hash of the name/value pairs for the entity.
+      # * +options+                  - Hash. Optional parameters. 
       #
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
-      # * +:timeout+      - Integer. A timeout in seconds.
+      # * +:timeout+                 - Integer. A timeout in seconds.
+      # * +:request_id+              - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+      #                                in the analytics logs when storage analytics logging is enabled.
       # 
       # See http://msdn.microsoft.com/en-us/library/azure/hh452242
       #
@@ -423,16 +447,18 @@ module Azure::Storage
       #
       # ==== Attributes
       #
-      # * +table_name+    - String. The table name
-      # * +partition_key+ - String. The partition key
-      # * +row_key+       - String. The row key
-      # * +options+       - Hash. Optional parameters.
+      # * +table_name+               - String. The table name
+      # * +partition_key+            - String. The partition key
+      # * +row_key+                  - String. The row key
+      # * +options+                  - Hash. Optional parameters.
       #
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
-      # * +:if_match+     - String. A matching condition which is required for update (optional, Default="*")
-      # * +:timeout+      - Integer. A timeout in seconds.
+      # * +:if_match+                - String. A matching condition which is required for update (optional, Default="*")
+      # * +:timeout+                 - Integer. A timeout in seconds.
+      # * +:request_id+              - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+      #                                in the analytics logs when storage analytics logging is enabled.
       #
       # See http://msdn.microsoft.com/en-us/library/azure/dd135727
       #
@@ -444,7 +470,7 @@ module Azure::Storage
         query = { }
         query["timeout"] = options[:timeout].to_s if options[:timeout]
 
-        call(:delete, entities_uri(table_name, partition_key, row_key, query), nil, { "If-Match"=> if_match })
+        call(:delete, entities_uri(table_name, partition_key, row_key, query), nil, { "If-Match"=> if_match }, options)
         nil
       end
 
@@ -452,13 +478,15 @@ module Azure::Storage
       #
       # ==== Attributes
       #
-      # * +batch+         - The Azure::Storage::Table::Batch instance to execute.
-      # * +options+       - Hash. Optional parameters.
+      # * +batch+                    - The Azure::Storage::Table::Batch instance to execute.
+      # * +options+                  - Hash. Optional parameters.
       #
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
-      # * +:timeout+      - Integer. A timeout in seconds.
+      # * +:timeout+                 - Integer. A timeout in seconds.
+      # * +:request_id+              - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+      #                                in the analytics logs when storage analytics logging is enabled.
       #
       # See http://msdn.microsoft.com/en-us/library/azure/dd894038
       #
@@ -474,7 +502,7 @@ module Azure::Storage
         query["timeout"] = options[:timeout].to_s if options[:timeout]
 
         body = batch.to_body
-        response = call(:post, generate_uri('/$batch', query), body, headers)
+        response = call(:post, generate_uri('/$batch', query), body, headers, options)
         batch.parse_response(response)
       rescue => e
         raise_with_response(e, response)
@@ -484,15 +512,17 @@ module Azure::Storage
       #
       # ==== Attributes
       #
-      # * +table_name+    - String. The table name
-      # * +partition_key+ - String. The partition key
-      # * +row_key+       - String. The row key
-      # * +options+       - Hash. Optional parameters.
+      # * +table_name+               - String. The table name
+      # * +partition_key+            - String. The partition key
+      # * +row_key+                  - String. The row key
+      # * +options+                  - Hash. Optional parameters.
       #
       # ==== Options
       #
       # Accepted key/value pairs in options parameter are:
-      # * +:timeout+      - Integer. A timeout in seconds.
+      # * +:timeout+                 - Integer. A timeout in seconds.
+      # * +:request_id+              - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+      #                                in the analytics logs when storage analytics logging is enabled.
       #
       # Returns an Azure::Storage::Table::Entity instance on success
       def get_entity(table_name, partition_key, row_key, options={})

--- a/lib/azure/storage/version.rb
+++ b/lib/azure/storage/version.rb
@@ -28,7 +28,7 @@ module Azure
       # Fields represent the parts defined in http://semver.org/
       MAJOR = 0 unless defined? MAJOR
       MINOR = 11 unless defined? MINOR
-      UPDATE = 0 unless defined? UPDATE
+      UPDATE = 1 unless defined? UPDATE
       PRE = 'preview' unless defined? PRE
 
       class << self

--- a/test/integration/table/delete_entity_batch_test.rb
+++ b/test/integration/table/delete_entity_batch_test.rb
@@ -90,7 +90,7 @@ describe Azure::Storage::Table::TableService do
     end
 
     it "errors on an invalid table name" do
-      assert_raises(Azure::Core::Http::HTTPError) do
+      assert_raises(RuntimeError) do
         batch = Azure::Storage::Table::Batch.new "this_table.cannot-exist!", entity_properties["PartitionKey"]
         batch.delete entity_properties["RowKey"]
         subject.execute_batch batch
@@ -98,7 +98,7 @@ describe Azure::Storage::Table::TableService do
     end
 
     it "errors on an invalid partition key" do
-      assert_raises(Azure::Core::Http::HTTPError) do
+      assert_raises(RuntimeError) do
         batch = Azure::Storage::Table::Batch.new table_name, "this_partition/key#is_invalid"
         batch.delete entity_properties["RowKey"]
         subject.execute_batch batch
@@ -106,7 +106,7 @@ describe Azure::Storage::Table::TableService do
     end
 
     it "errors on an invalid row key" do
-      assert_raises(Azure::Core::Http::HTTPError) do
+      assert_raises(RuntimeError) do
         batch = Azure::Storage::Table::Batch.new table_name, entity_properties["PartitionKey"]
         batch.delete "thisrow/key#is_invalid"
         subject.execute_batch batch

--- a/test/integration/table/insert_entity_batch_test.rb
+++ b/test/integration/table/insert_entity_batch_test.rb
@@ -77,7 +77,7 @@ describe Azure::Storage::Table::TableService do
     end
 
     it "errors on an invalid table name" do
-      assert_raises(Azure::Core::Http::HTTPError) do
+      assert_raises(RuntimeError) do
         batch = Azure::Storage::Table::Batch.new "this_table.cannot-exist!", entity_properties["PartitionKey"]
         batch.insert entity_properties["RowKey"], entity_properties
         results = subject.execute_batch batch
@@ -85,7 +85,7 @@ describe Azure::Storage::Table::TableService do
     end
 
     it "errors on an invalid partition key" do
-      assert_raises(Azure::Core::Http::HTTPError) do
+      assert_raises(RuntimeError) do
         entity = entity_properties.dup
         entity["PartitionKey"] = "this/partition\\key#is?invalid"
 
@@ -96,7 +96,7 @@ describe Azure::Storage::Table::TableService do
     end
 
     it "errors on an invalid row key" do
-      assert_raises(Azure::Core::Http::HTTPError) do
+      assert_raises(RuntimeError) do
         entity = entity_properties.dup
         entity["RowKey"] = "this/row\\key#is?invalid"
 

--- a/test/integration/table/insert_or_merge_entity_batch_test.rb
+++ b/test/integration/table/insert_or_merge_entity_batch_test.rb
@@ -132,7 +132,7 @@ describe Azure::Storage::Table::TableService do
     end
 
     it "errors on an invalid table name" do
-      assert_raises(Azure::Core::Http::HTTPError) do
+      assert_raises(RuntimeError) do
         entity = entity_properties.dup
         entity["RowKey"] = "row_key"
 
@@ -143,7 +143,7 @@ describe Azure::Storage::Table::TableService do
     end
 
     it "errors on an invalid partition key" do
-      assert_raises(Azure::Core::Http::HTTPError) do
+      assert_raises(RuntimeError) do
         entity = entity_properties.dup
         entity["PartitionKey"] = "this/partition_key#is?invalid"
         entity["RowKey"] = "row_key"
@@ -155,7 +155,7 @@ describe Azure::Storage::Table::TableService do
     end
 
     it "errors on an invalid row key" do
-      assert_raises(Azure::Core::Http::HTTPError) do
+      assert_raises(RuntimeError) do
         entity = entity_properties.dup
         entity["RowKey"] = "this/partition_key#is?invalid"
 

--- a/test/integration/table/insert_or_replace_entity_batch_test.rb
+++ b/test/integration/table/insert_or_replace_entity_batch_test.rb
@@ -125,7 +125,7 @@ describe Azure::Storage::Table::TableService do
     end
 
     it "errors on an invalid table name" do
-      assert_raises(Azure::Core::Http::HTTPError) do
+      assert_raises(RuntimeError) do
         entity = entity_properties.dup
         entity["RowKey"] = "row_key"
 
@@ -136,7 +136,7 @@ describe Azure::Storage::Table::TableService do
     end
 
     it "errors on an invalid partition key" do
-      assert_raises(Azure::Core::Http::HTTPError) do
+      assert_raises(RuntimeError) do
         entity = entity_properties.dup
         entity["PartitionKey"] = "this/partition_key#is?invalid"
         entity["RowKey"] = "row_key"
@@ -148,7 +148,7 @@ describe Azure::Storage::Table::TableService do
     end
 
     it "errors on an invalid row key" do
-      assert_raises(Azure::Core::Http::HTTPError) do
+      assert_raises(RuntimeError) do
         entity = entity_properties.dup
         entity["RowKey"] = "this/partition_key#is?invalid"
 

--- a/test/integration/table/merge_entity_batch_test.rb
+++ b/test/integration/table/merge_entity_batch_test.rb
@@ -94,7 +94,7 @@ describe Azure::Storage::Table::TableService do
     end
 
     it "errors on a non-existing row key" do
-      assert_raises(Azure::Core::Http::HTTPError) do
+      assert_raises(RuntimeError) do
         entity = entity_properties.dup
         entity["RowKey"] = "this-row-key-does-not-exist"
 
@@ -105,7 +105,7 @@ describe Azure::Storage::Table::TableService do
     end
 
     it "errors on an invalid table name" do
-      assert_raises(Azure::Core::Http::HTTPError) do
+      assert_raises(RuntimeError) do
         batch = Azure::Storage::Table::Batch.new "this_table.cannot-exist!", entity_properties["PartitionKey"]
         batch.merge entity_properties["RowKey"], entity_properties
         etags = subject.execute_batch batch
@@ -113,7 +113,7 @@ describe Azure::Storage::Table::TableService do
     end
 
     it "errors on an invalid partition key" do
-      assert_raises(Azure::Core::Http::HTTPError) do
+      assert_raises(RuntimeError) do
         entity = entity_properties.dup
         entity["PartitionKey"] = "this/partition_key#is?invalid"
 
@@ -124,7 +124,7 @@ describe Azure::Storage::Table::TableService do
     end
 
     it "errors on an invalid row key" do
-      assert_raises(Azure::Core::Http::HTTPError) do
+      assert_raises(RuntimeError) do
         entity = entity_properties.dup
         entity["RowKey"] = "this/row_key#is?invalid"
 

--- a/test/integration/table/update_entity_batch_test.rb
+++ b/test/integration/table/update_entity_batch_test.rb
@@ -115,7 +115,7 @@ describe Azure::Storage::Table::TableService do
     end
 
     it "errors on a non-existing row key" do
-      assert_raises(Azure::Core::Http::HTTPError) do
+      assert_raises(RuntimeError) do
         entity = entity_properties.dup
         entity["RowKey"] = "this-row-key-does-not-exist"
 
@@ -126,7 +126,7 @@ describe Azure::Storage::Table::TableService do
     end
 
     it "errors on an invalid table name" do
-      assert_raises(Azure::Core::Http::HTTPError) do
+      assert_raises(RuntimeError) do
         batch = Azure::Storage::Table::Batch.new "this_table.cannot-exist!", entity_properties["PartitionKey"]
         batch.update entity_properties["RowKey"], entity_properties
         etags = subject.execute_batch batch
@@ -134,7 +134,7 @@ describe Azure::Storage::Table::TableService do
     end
 
     it "errors on an invalid partition key" do
-      assert_raises(Azure::Core::Http::HTTPError) do
+      assert_raises(RuntimeError) do
         entity = entity_properties.dup
         entity["PartitionKey"] = "this/partition_key#is?invalid"
 
@@ -145,7 +145,7 @@ describe Azure::Storage::Table::TableService do
     end
 
     it "errors on an invalid row key" do
-      assert_raises(Azure::Core::Http::HTTPError) do
+      assert_raises(RuntimeError) do
         entity = entity_properties.dup
         entity["RowKey"] = "this/row_key#is?invalid"
 

--- a/test/integration/test_helper.rb
+++ b/test/integration/test_helper.rb
@@ -28,4 +28,6 @@ Azure::Storage.configure do |config|
   config.storage_access_key       = ENV.fetch('AZURE_STORAGE_ACCESS_KEY')
   config.storage_account_name     = ENV.fetch('AZURE_STORAGE_ACCOUNT')
   Azure::Storage.client(:storage_account_name => config.storage_account_name, :storage_access_key => config.storage_access_key)
+  require "azure/core/http/debug_filter"
+  Azure::Storage.client.blob_client.with_filter Azure::Core::Http::DebugFilter.new
 end

--- a/test/unit/service/storage_service_test.rb
+++ b/test/unit/service/storage_service_test.rb
@@ -56,6 +56,18 @@ describe Azure::Storage::Service::StorageService do
       mock_request.expects(:call)
     end
 
+    it 'adds a client request id' do
+      Azure::Core::Http::HttpRequest.stubs(:new).with(verb,
+                                                        uri,
+                                                        {
+                                                            body: nil,
+                                                            headers: {'x-ms-client-request-id' => 'client-request-id'},
+                                                            client: nil
+                                                        }).returns(mock_request)
+      mock_request.expects(:with_filter).with(mock_signer_filter)
+      subject.call(verb, uri, nil, {}, {:request_id => 'client-request-id'})
+    end
+
     it 'adds a SignerFilter to the HTTP pipeline' do
       mock_request.expects(:with_filter).with(mock_signer_filter)
       subject.call(verb, uri)
@@ -160,7 +172,7 @@ describe Azure::Storage::Service::StorageService do
     before do
       Azure::Storage::Service::Serialization.stubs(:service_properties_from_xml).with(service_properties_xml).returns(service_properties)
       subject.stubs(:service_properties_uri).returns(service_properties_uri)
-      subject.stubs(:call).with(:get, service_properties_uri).returns(response)
+      subject.stubs(:call).with(:get, service_properties_uri, nil, {}, {}).returns(response)
     end
 
     it 'calls the service_properties_uri method to determine the correct uri' do
@@ -169,7 +181,7 @@ describe Azure::Storage::Service::StorageService do
     end
 
     it 'gets the response from the HTTP API' do
-      subject.expects(:call).with(:get, service_properties_uri).returns(response)
+      subject.expects(:call).with(:get, service_properties_uri, nil, {}, {}).returns(response)
       subject.get_service_properties
     end
 
@@ -198,7 +210,7 @@ describe Azure::Storage::Service::StorageService do
     before do
       Azure::Storage::Service::Serialization.stubs(:service_properties_to_xml).with(service_properties).returns(service_properties_xml)
       subject.stubs(:service_properties_uri).returns(service_properties_uri)
-      subject.stubs(:call).with(:put, service_properties_uri, service_properties_xml).returns(response)
+      subject.stubs(:call).with(:put, service_properties_uri, service_properties_xml, {}, {}).returns(response)
     end
 
     it 'calls the service_properties_uri method to determine the correct uri' do
@@ -207,7 +219,7 @@ describe Azure::Storage::Service::StorageService do
     end
 
     it 'posts to the HTTP API' do
-      subject.expects(:call).with(:put, service_properties_uri, service_properties_xml).returns(response)
+      subject.expects(:call).with(:put, service_properties_uri, service_properties_xml, {}, {}).returns(response)
       subject.set_service_properties service_properties
     end
 


### PR DESCRIPTION
2016.09 - version 0.11.1-preview

ALL
* Added the support for setting the client request ID via the "request_id" parameter.
* Added the retry for the timeout errors.
* Added the retry for the connection reset error.

BLOB
* Fixed the issue where "list_blobs" doesn't work when delimiter is specified. (https://github.com/Azure/azure-storage-ruby/issues/41)