### PR TITLE
Changes for 0.11.4-preview

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,12 @@
+2016.11 - version 0.11.4-preview
+
+ALL
+* Removed the unnecessary dependencies. This resolves: [#55](https://github.com/Azure/azure-storage-ruby/issues/55), [#67](https://github.com/Azure/azure-storage-ruby/issues/67)
+
+BLOB
+* Fixed the issue when checking the content encoding.
+* Fixed the wrong "Content-Encoding" value in the test cases.
+
 2016.10 - version 0.11.3-preview
 
 ALL

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,11 +1,12 @@
 2016.11 - version 0.11.4-preview
 
 ALL
-* Removed the unnecessary dependencies. This resolves: [#55](https://github.com/Azure/azure-storage-ruby/issues/55), [#67](https://github.com/Azure/azure-storage-ruby/issues/67)
+* Removed the unnecessary dependencies. [#55](https://github.com/Azure/azure-storage-ruby/issues/55), [#67](https://github.com/Azure/azure-storage-ruby/issues/67)
 
 BLOB
 * Fixed the issue when checking the content encoding.
 * Fixed the wrong "Content-Encoding" value in the test cases.
+* Fixed the issue where it cannot use the `create_block_blob` method with an IO/File object. [#61](https://github.com/Azure/azure-storage-ruby/issues/61)
 
 2016.10 - version 0.11.3-preview
 

--- a/azure-storage.gemspec
+++ b/azure-storage.gemspec
@@ -38,21 +38,16 @@ Gem::Specification.new do |s|
   
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_runtime_dependency('addressable',             '~> 2.3')
   s.add_runtime_dependency('azure-core',              '~> 0.1')
   s.add_runtime_dependency('faraday',                 '~> 0.9')
   s.add_runtime_dependency('faraday_middleware',      '~> 0.10')
-  s.add_runtime_dependency('json',                    '~> 1.8')
-  s.add_runtime_dependency('mime-types',              '~> 2.0')
   s.add_runtime_dependency('nokogiri',                '~> 1.6')
-  s.add_runtime_dependency('systemu',                 '~> 2.6')
-  s.add_runtime_dependency('thor',                    '~> 0.19')
   
-  s.add_development_dependency('dotenv',              '~> 2.0') 
-  s.add_development_dependency('minitest',            '~> 5') 
-  s.add_development_dependency('minitest-reporters',  '~> 1') 
-  s.add_development_dependency('mocha',               '~> 1.0') 
-  s.add_development_dependency('rake',                '~> 10.0') 
-  s.add_development_dependency('timecop',             '~> 0.7') 
+  s.add_development_dependency('dotenv',              '~> 2.0')
+  s.add_development_dependency('minitest',            '~> 5')
+  s.add_development_dependency('minitest-reporters',  '~> 1')
+  s.add_development_dependency('mocha',               '~> 1.0')
+  s.add_development_dependency('rake',                '~> 10.0')
+  s.add_development_dependency('timecop',             '~> 0.7')
   s.add_development_dependency('yard',                '~> 0.8')
 end

--- a/lib/azure/storage.rb
+++ b/lib/azure/storage.rb
@@ -27,8 +27,6 @@ require 'nokogiri'
 require 'base64'
 require 'openssl'
 require 'uri'
-require 'rexml/document'
-require 'addressable/uri'
 require 'faraday'
 require 'faraday_middleware'
 

--- a/lib/azure/storage/blob/blob.rb
+++ b/lib/azure/storage/blob/blob.rb
@@ -125,7 +125,7 @@ module Azure::Storage
     #
     # See http://msdn.microsoft.com/en-us/library/azure/dd179394.aspx
     #
-    # Returns a Blob
+    # Returns the blob properties
     def get_blob_properties(container, blob, options={})
       query = { }
       StorageService.with_query query, 'snapshot', options[:snapshot]

--- a/lib/azure/storage/blob/blob_service.rb
+++ b/lib/azure/storage/blob/blob_service.rb
@@ -47,12 +47,12 @@ module Azure::Storage
 
       def call(method, uri, body=nil, headers={}, options={})
         # Force the request.body to the content encoding of specified in the header
-        if headers && !body.nil? && !(body.encoding.to_s <=> 'ASCII_8BIT')
+        if headers && !body.nil? && ((body.encoding.to_s <=> 'ASCII_8BIT') != 0)
           if headers['x-ms-blob-content-type'].nil?
             Service::StorageService.with_header headers, 'x-ms-blob-content-type', "text/plain; charset=#{body.encoding.to_s}"
           else
             charset = parse_charset_from_content_type(headers['x-ms-blob-content-type'])
-            body.force_encoding(charset)
+            body.force_encoding(charset) if charset
           end
         end
 

--- a/lib/azure/storage/blob/blob_service.rb
+++ b/lib/azure/storage/blob/blob_service.rb
@@ -47,7 +47,7 @@ module Azure::Storage
 
       def call(method, uri, body=nil, headers={}, options={})
         # Force the request.body to the content encoding of specified in the header
-        if headers && !body.nil? && ((body.encoding.to_s <=> 'ASCII_8BIT') != 0)
+        if headers && !body.nil? && (body.is_a? String) && ((body.encoding.to_s <=> 'ASCII_8BIT') != 0)
           if headers['x-ms-blob-content-type'].nil?
             Service::StorageService.with_header headers, 'x-ms-blob-content-type', "text/plain; charset=#{body.encoding.to_s}"
           else

--- a/lib/azure/storage/version.rb
+++ b/lib/azure/storage/version.rb
@@ -28,7 +28,7 @@ module Azure
       # Fields represent the parts defined in http://semver.org/
       MAJOR = 0 unless defined? MAJOR
       MINOR = 11 unless defined? MINOR
-      UPDATE = 3 unless defined? UPDATE
+      UPDATE = 4 unless defined? UPDATE
       PRE = 'preview' unless defined? PRE
 
       class << self

--- a/test/integration/blob/append_blob_test.rb
+++ b/test/integration/blob/append_blob_test.rb
@@ -60,7 +60,7 @@ describe Azure::Storage::Blob::BlobService do
     it 'sets additional properties when the options hash is used' do
       options = {
         :content_type=>"application/xml",
-        :content_encoding=>"utf-8",
+        :content_encoding=>"gzip",
         :content_language=>"en-US",
         :cache_control=>"max-age=1296000",
         :metadata => { "CustomMetadataProperty"=>"CustomMetadataValue"}

--- a/test/integration/blob/blob_properties_test.rb
+++ b/test/integration/blob/blob_properties_test.rb
@@ -38,7 +38,7 @@ describe Azure::Storage::Blob::BlobService do
     }
     let(:options){{
         :content_type=>"application/my-special-format",
-        :content_encoding=>"utf-16",
+        :content_encoding=>"gzip",
         :content_language=>"klingon",
         :cache_control=>"max-age=1296000",
       }}

--- a/test/integration/blob/block_blob_test.rb
+++ b/test/integration/blob/block_blob_test.rb
@@ -57,7 +57,7 @@ describe Azure::Storage::Blob::BlobService do
     it 'sets additional properties when the options hash is used' do
       options = {
         :content_type=>"application/xml",
-        :content_encoding=>"utf-8",
+        :content_encoding=>"gzip",
         :content_language=>"en-US",
         :cache_control=>"max-age=1296000",
         :metadata => { "CustomMetadataProperty"=>"CustomMetadataValue"}

--- a/test/integration/blob/block_blob_test.rb
+++ b/test/integration/blob/block_blob_test.rb
@@ -41,6 +41,23 @@ describe Azure::Storage::Blob::BlobService do
       blob = subject.create_block_blob container_name, blob_name, content
       blob.name.must_equal blob_name
     end
+
+    it 'creates a block blob with IO' do
+      begin
+        file = File.open blob_name, 'w+'
+        file.write content
+        file.seek 0
+        subject.create_block_blob container_name, blob_name, file
+        blob = subject.get_blob_properties container_name, blob_name
+        blob.name.must_equal blob_name
+        blob.properties[:content_length].must_equal content.length
+      ensure
+        unless file.nil?
+          file.close
+          File.delete blob_name
+        end
+      end
+    end
     
     it 'should create a block blob with spaces in name' do  
       blob_name = 'blob with spaces'  

--- a/test/integration/blob/create_page_blob_test.rb
+++ b/test/integration/blob/create_page_blob_test.rb
@@ -64,7 +64,7 @@ describe Azure::Storage::Blob::BlobService do
     it 'sets additional properties when the options hash is used' do
       options = {
         :content_type=>"application/xml",
-        :content_encoding=>"utf-8",
+        :content_encoding=>"gzip",
         :content_language=>"en-US",
         :cache_control=>"max-age=1296000",
         :metadata => { "CustomMetadataProperty"=>"CustomMetadataValue"}

--- a/test/unit/core/auth/shared_access_signature_test.rb
+++ b/test/unit/core/auth/shared_access_signature_test.rb
@@ -40,7 +40,7 @@ describe Azure::Storage::Core::Auth::SharedAccessSignature do
       ip_range:             '168.1.5.60-168.1.5.70',
       cache_control:        'public',
       content_disposition:  'inline, filename=nyan.cat',
-      content_encoding:     'utf-8',
+      content_encoding:     'gzip',
       content_language:     'English',
       content_type:         'binary'
     }
@@ -66,7 +66,7 @@ describe Azure::Storage::Core::Auth::SharedAccessSignature do
       subject.signable_string_for_service(service_type, path, service_options).must_equal(
         "rwd\n#{Time.parse('2020-12-10T00:00:00Z').utc.iso8601}\n#{Time.parse('2020-12-11T00:00:00Z').utc.iso8601}\n" + 
         "/blob/account-name/example/path\n\n168.1.5.60-168.1.5.70\nhttps,http\n#{Azure::Storage::Default::STG_VERSION}\n" +
-        "public\ninline, filename=nyan.cat\nutf-8\nEnglish\nbinary"
+        "public\ninline, filename=nyan.cat\ngzip\nEnglish\nbinary"
       )
     end
 
@@ -95,7 +95,7 @@ describe Azure::Storage::Core::Auth::SharedAccessSignature do
       query_hash['spr'].must_equal 'https,http'
       query_hash['rscc'].must_equal 'public'
       query_hash['rscd'].must_equal 'inline, filename=nyan.cat'
-      query_hash['rsce'].must_equal 'utf-8'
+      query_hash['rsce'].must_equal 'gzip'
       query_hash['rscl'].must_equal 'English'
       query_hash['rsct'].must_equal 'binary'
     end


### PR DESCRIPTION
2016.11 - version 0.11.4-preview

ALL
* Removed the unnecessary dependencies. [#55](https://github.com/Azure/azure-storage-ruby/issues/55), [#67](https://github.com/Azure/azure-storage-ruby/issues/67)

BLOB
* Fixed the issue when checking the content encoding.
* Fixed the wrong "Content-Encoding" value in the test cases.
* Fixed the issue where it cannot use the `create_block_blob` method with an IO/File object. [#61](https://github.com/Azure/azure-storage-ruby/issues/61)