### PR TITLE
Changes for 0.12.0-preview 

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,8 @@
+2017.02 - version 0.12.0-preview
+
+BLOB
+* Added the metadata to the returning instance when creates a blob.
+
 2016.12 - version 0.11.5-preview
 
 ALL

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,11 @@
 2017.02 - version 0.12.0-preview
 
+ALL
+* Fixed the issue where `should_retry?` in the retry_filter.rb overwrites the result from derived `apply_retry_policy`. [#76](https://github.com/Azure/azure-storage-ruby/issues/76)
+
 BLOB
 * Added the metadata to the returning instance when creates a blob.
+* Added `transactional_md5` to the options of `put_blob_pages`.
 
 FILE
 * Added File Service support, targeting storage service version 2015-04-05.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,7 @@
 
 ALL
 * Fixed the issue where `should_retry?` in the retry_filter.rb overwrites the result from derived `apply_retry_policy`. [#76](https://github.com/Azure/azure-storage-ruby/issues/76)
+* Fixed the issue where `Azure::Storage::Client.create_from_connection_string` throws an exception. [#77](https://github.com/Azure/azure-storage-ruby/issues/77)
 
 BLOB
 * Added the metadata to the returning instance when creates a blob.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,7 @@
 ALL
 * Fixed the issue where `should_retry?` in the retry_filter.rb overwrites the result from derived `apply_retry_policy`. [#76](https://github.com/Azure/azure-storage-ruby/issues/76)
 * Fixed the issue where `Azure::Storage::Client.create_from_connection_string` throws an exception. [#77](https://github.com/Azure/azure-storage-ruby/issues/77)
+* Added the support for setting the "timeout" option in `get_service_properties` and `set_service_properties`.
 
 BLOB
 * Added the metadata to the returning instance when creates a blob.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,9 @@
 BLOB
 * Added the metadata to the returning instance when creates a blob.
 
+FILE
+* Added File Service support, targeting storage service version 2015-04-05.
+
 2016.12 - version 0.11.5-preview
 
 ALL

--- a/README.md
+++ b/README.md
@@ -48,17 +48,17 @@ There are two ways you can set up the connections:
 
 ```ruby
 
-  require "azure/storage"
+  require 'azure/storage'
 
   # Setup a specific instance of an Azure::Storage::Client
-  client = Azure::Storage::Client.create(:storage_account_name => "your account name", :storage_access_key => "your access key")
+  client = Azure::Storage::Client.create(:storage_account_name => 'your account name', :storage_access_key => 'your access key')
 
   # Or create a client and store as a singleton
-  Azure::Storage.setup(:storage_account_name => "your account name", :storage_access_key => "your access key")
+  Azure::Storage.setup(:storage_account_name => 'your account name', :storage_access_key => 'your access key')
   # Then you can either call Azure::Storage.client.some_method or Azure::Storage.some_method to invoke a method on the Storage Client
 
   # Configure a ca_cert.pem file if you are having issues with ssl peer verification
-  client.ca_file = "./ca_file.pem"
+  client.ca_file = './ca_file.pem'
 
 ```
 
@@ -66,11 +66,11 @@ There are two ways you can set up the connections:
 
 ```ruby
 
-  require "azure/storage"
+  require 'azure/storage'
   client = Azure::Storage::Client.create_develpoment
 
   # Or create by options and provide your own proxy_uri
-  client = Azure::Storage::Client.create(:use_development_storage => true, :development_storage_proxy_uri => "your proxy uri")
+  client = Azure::Storage::Client.create(:use_development_storage => true, :development_storage_proxy_uri => 'your proxy uri')
 
 ```
 
@@ -104,16 +104,16 @@ There are two ways you can set up the connections:
 ```ruby
 
 # Require the azure storage rubygem
-require "azure/storage"
+require 'azure/storage'
 
 # Setup a specific instance of an Azure::Storage::Client
-client = Azure::Storage::Client.create(:storage_account_name => "your account name", :storage_access_key => "your access key")
+client = Azure::Storage::Client.create(:storage_account_name => 'your account name', :storage_access_key => 'your access key')
 
 # Get an azure storage blob service object from a specific instance of an Azure::Storage::Client
 blobs = client.blob_client
 
 # Or setup the client as a singleton
-Azure::Storage.setup(:storage_account_name => "your account name", :storage_access_key => "your access key")
+Azure::Storage.setup(:storage_account_name => 'your account name', :storage_access_key => 'your access key')
 
 # Create an azure storage blob service object after you set up the credentials
 blobs = Azure::Storage::Blob::BlobService.new
@@ -122,11 +122,11 @@ blobs = Azure::Storage::Blob::BlobService.new
 blobs.with_filter(Azure::Storage::Core::Filter::ExponentialRetryPolicyFilter.new)
 
 # Create a container
-container = blobs.create_container("test-container")
+container = blobs.create_container('test-container')
 
 # Upload a Blob
-content = File.open('test.jpg', 'rb') { |file| file.read }
-blobs.create_block_blob(container.name, "image-blob", content)
+content = ::File.open('test.jpg', 'rb') { |file| file.read }
+blobs.create_block_blob(container.name, 'image-blob', content)
 
 # List containers
 blobs.list_containers()
@@ -135,11 +135,11 @@ blobs.list_containers()
 blobs.list_blobs(container.name)
 
 # Download a Blob
-blob, content = blobs.get_blob(container.name, "image-blob")
-File.open("download.png", "wb") {|f| f.write(content)}
+blob, content = blobs.get_blob(container.name, 'image-blob')
+::File.open('download.png', 'wb') {|f| f.write(content)}
 
 # Delete a Blob
-blobs.delete_blob(container.name, "image-blob")
+blobs.delete_blob(container.name, 'image-blob')
 
 ```
 <a name="tables"></a>
@@ -148,16 +148,16 @@ blobs.delete_blob(container.name, "image-blob")
 ```ruby
 
 # Require the azure storage rubygem
-require "azure/storage"
+require 'azure/storage'
 
 # Setup a specific instance of an Azure::Storage::Client
-client = Azure::Storage::Client.create(:storage_account_name => "your account name", :storage_access_key => "your access key")
+client = Azure::Storage::Client.create(:storage_account_name => 'your account name', :storage_access_key => 'your access key')
 
 # Get an azure storage table service object from a specific instance of an Azure::Storage::Client
 tables = client.table_client
 
 # Or setup the client as a singleton
-Azure::Storage.setup(:storage_account_name => "your account name", :storage_access_key => "your access key")
+Azure::Storage.setup(:storage_account_name => 'your account name', :storage_access_key => 'your access key')
 
 # Create an azure storage table service object after you set up the credentials
 tables = Azure::Storage::Table::TableService.new
@@ -166,28 +166,28 @@ tables = Azure::Storage::Table::TableService.new
 tables.with_filter(Azure::Storage::Core::Filter::ExponentialRetryPolicyFilter.new)
 
 # Create a table
-tables.create_table("testtable")
+tables.create_table('testtable')
 
 # Insert an entity
-entity = { content: "test entity", PartitionKey: "test-partition-key", RowKey: "1" }
-tables.insert_entity("testtable", entity)
+entity = { content: 'test entity', PartitionKey: 'test-partition-key', RowKey: '1' }
+tables.insert_entity('testtable', entity)
 
 # Get an entity
-result = tables.get_entity("testtable", "test-partition-key", "1")
+result = tables.get_entity('testtable', 'test-partition-key', '1')
 
 # Update an entity
-result.properties["content"] = "test entity with updated content"
+result.properties['content'] = 'test entity with updated content'
 tables.update_entity(result.table, result.properties)
 
 # Query entities
 query = { :filter => "content eq 'test entity'" }
-result, token = tables.query_entities("testtable", query)
+result, token = tables.query_entities('testtable', query)
 
 # Delete an entity
-tables.delete_entity("testtable", "test-partition-key", "1")
+tables.delete_entity('testtable', 'test-partition-key', '1')
 
 # delete a table
-tables.delete_table("testtable")
+tables.delete_table('testtable')
 
 ```
 
@@ -197,16 +197,16 @@ tables.delete_table("testtable")
 ```ruby
 
 # Require the azure storage rubygem
-require "azure/storage"
+require 'azure/storage'
 
 # Setup a specific instance of an Azure::Storage::Client
-client = Azure::Storage::Client.create(:storage_account_name => "your account name", :storage_access_key => "your access key")
+client = Azure::Storage::Client.create(:storage_account_name => 'your account name', :storage_access_key => 'your access key')
 
 # Get an azure storage queue service object from a specific instance of an Azure::Storage::Client
 queues = client.queue_client
 
 # Or setup the client as a singleton
-Azure::Storage.setup(:storage_account_name => "your account name", :storage_access_key => "your access key")
+Azure::Storage.setup(:storage_account_name => 'your account name', :storage_access_key => 'your access key')
 
 # Create an azure storage queue service object after you set up the credentials
 queues = Azure::Storage::Queue::QueueService.new
@@ -215,28 +215,75 @@ queues = Azure::Storage::Queue::QueueService.new
 queues.with_filter(Azure::Storage::Core::Filter::ExponentialRetryPolicyFilter.new)
 
 # Create a queue
-queues.create_queue("test-queue")
+queues.create_queue('test-queue')
 
 # Create a message
-queues.create_message("test-queue", "test message")
+queues.create_message('test-queue', 'test message')
 
 # Get one or more messages with setting the visibility timeout
-result = queues.list_messages("test-queue", 30, { number_of_messages: 10 })
+result = queues.list_messages('test-queue', 30, { number_of_messages: 10 })
 
 # Get one or more messages without setting the visibility timeout
-result = queues.peek_messages("test-queue", { number_of_messages: 10 })
+result = queues.peek_messages('test-queue', { number_of_messages: 10 })
 
 # Update a message
-message = queues.list_messages("test-queue", 30)
-pop_receipt, time_next_visible = queues.update_message("test-queue", message[0].id, message[0].pop_receipt, "updated test message", 30)
+message = queues.list_messages('test-queue', 30)
+pop_receipt, time_next_visible = queues.update_message('test-queue', message[0].id, message[0].pop_receipt, 'updated test message', 30)
 
 # Delete a message
-message = queues.list_messages("test-queue", 30)
-queues.delete_message("test-queue", message[0].id, message[0].pop_receipt)
+message = queues.list_messages('test-queue', 30)
+queues.delete_message('test-queue', message[0].id, message[0].pop_receipt)
 
 # Delete a queue
-queues.delete_queue("test-queue")
+queues.delete_queue('test-queue')
 
+```
+
+<a name="files"></a>
+## Files
+
+```ruby
+# Require the azure storage rubygem
+require 'azure/storage'
+
+# Setup a specific instance of an Azure::Storage::Client
+client = Azure::Storage::Client.create(:storage_account_name => 'your account name', :storage_access_key => 'your access key')
+
+# Get an azure storage file service object from a specific instance of an Azure::Storage::Client
+files = client.file_client
+
+# Or setup the client as a singleton
+Azure::Storage.setup(:storage_account_name => 'your account name', :storage_access_key => 'your access key')
+
+# Create an azure storage file service object after you set up the credentials
+files = Azure::Storage::File::FileService.new
+
+# Add retry filter to the service object
+files.with_filter(Azure::Storage::Core::Filter::ExponentialRetryPolicyFilter.new)
+
+# Create a share
+share = files.create_share('test-share')
+
+# Create a directory
+directory = files.create_directory(share.name, 'test-directory')
+
+# Create a file and update the file content
+content = ::File.open('test.jpg', 'rb') { |file| file.read }
+file = files.create_file(share.name, directory.name, 'test-file', content.size)
+files.put_file_range(share.name, directory.name, file.name, 0, content.size - 1, content)
+
+# List shares
+files.list_shares()
+
+# List directories and files
+files.list_directories_and_files(share.name, directory.name)
+
+# Download a File
+file, content = files.get_file(share.name, directory.name, file.name)
+::File.open('download.png', 'wb') {|f| f.write(content)}
+
+# Delete a File
+files.delete_file(share.name, directory.name, file.name)
 ```
 
 <a name="Customize the user-agent"></a>

--- a/lib/azure/storage/autoload.rb
+++ b/lib/azure/storage/autoload.rb
@@ -65,5 +65,13 @@ module Azure
       autoload :Query,                    'azure/storage/table/query'
     end
 
+    module File
+      autoload :FileService,              'azure/storage/file/file_service'
+      autoload :Share,                    'azure/storage/file/share'
+      autoload :Directory,                'azure/storage/file/directory'
+      autoload :File,                     'azure/storage/file/file'
+      autoload :Serialization,            'azure/storage/file/serialization'
+    end
+
   end
 end

--- a/lib/azure/storage/blob/append.rb
+++ b/lib/azure/storage/blob/append.rb
@@ -96,6 +96,7 @@ module Azure::Storage
 
       result = Serialization.blob_from_headers(response.headers)
       result.name = blob
+      result.metadata = options[:metadata] if options[:metadata]
 
       result
     end

--- a/lib/azure/storage/blob/blob.rb
+++ b/lib/azure/storage/blob/blob.rb
@@ -125,7 +125,7 @@ module Azure::Storage
     #
     # See http://msdn.microsoft.com/en-us/library/azure/dd179394.aspx
     #
-    # Returns the blob properties
+    # Returns the blob properties with a Blob instance
     def get_blob_properties(container, blob, options={})
       query = { }
       StorageService.with_query query, 'snapshot', options[:snapshot]

--- a/lib/azure/storage/blob/blob.rb
+++ b/lib/azure/storage/blob/blob.rb
@@ -620,13 +620,13 @@ module Azure::Storage
       response.headers['x-ms-snapshot']
     end
     
-    # Public: Copies a source blob to a destination blob.
+    # Public: Copies a source blob or file to a destination blob.
     #
     # ==== Attributes
     #
-    # * +source_container+           - String. The destination container name to copy to.
-    # * +source_blob+                - String. The destination blob name to copy to.
-    # * +source_blob_uri+            - String. The source blob URI to copy from.
+    # * +destination_container+      - String. The destination container name to copy to.
+    # * +destination_blob+           - String. The destination blob name to copy to.
+    # * +source_uri+                 - String. The source blob or file URI to copy from.
     # * +options+                    - Hash. Optional parameters.
     #
     # ==== Options
@@ -675,13 +675,13 @@ module Azure::Storage
     #                                    "success" - The copy completed successfully.
     #                                    "pending" - The copy is in progress.
     #
-    def copy_blob_from_uri(destination_container, destination_blob, source_blob_uri, options={})
+    def copy_blob_from_uri(destination_container, destination_blob, source_uri, options={})
       query = { }
       StorageService.with_query query, 'timeout', options[:timeout].to_s if options[:timeout]
 
       uri = blob_uri(destination_container, destination_blob, query)
       headers = StorageService.common_headers
-      StorageService.with_header headers, 'x-ms-copy-source', source_blob_uri
+      StorageService.with_header headers, 'x-ms-copy-source', source_uri
 
       unless options.empty?
         add_blob_conditional_headers options, headers
@@ -696,8 +696,8 @@ module Azure::Storage
     #
     # ==== Attributes
     #
-    # * +source_container+           - String. The destination container name to copy to.
-    # * +source_blob+                - String. The destination blob name to copy to.
+    # * +destination_container+      - String. The destination container name to copy to.
+    # * +destination_blob+           - String. The destination blob name to copy to.
     # * +source_container+           - String. The source container name to copy from.
     # * +source_blob+                - String. The source blob name to copy from.
     # * +options+                    - Hash. Optional parameters.

--- a/lib/azure/storage/blob/blob_service.rb
+++ b/lib/azure/storage/blob/blob_service.rb
@@ -471,7 +471,7 @@ module Azure::Storage
         else
           path = ::File.join(container_name, blob_name)
         end
-        generate_uri(path, query)
+        generate_uri(path, query, true)
       end
       
       # Adds conditional header with required condition

--- a/lib/azure/storage/blob/blob_service.rb
+++ b/lib/azure/storage/blob/blob_service.rb
@@ -40,7 +40,7 @@ module Azure::Storage
       
       def initialize(options = {}, &block)
         client_config = options[:client] || Azure::Storage
-        signer = options[:signer] || Azure::Storage::Core::Auth::SharedKey.new(client_config.storage_account_name, client_config.storage_access_key)
+        signer = options[:signer] || client_config.signer || Azure::Storage::Core::Auth::SharedKey.new(client_config.storage_account_name, client_config.storage_access_key)
         super(signer, client_config.storage_account_name, options, &block)
         @host = client.storage_blob_host
       end

--- a/lib/azure/storage/blob/blob_service.rb
+++ b/lib/azure/storage/blob/blob_service.rb
@@ -469,18 +469,8 @@ module Azure::Storage
         if container_name.nil? || container_name.empty?
           path = blob_name
         else
-          path = File.join(container_name, blob_name)
+          path = ::File.join(container_name, blob_name)
         end
-
-        path = CGI.escape(path.encode('UTF-8'))
-
-        # Unencode the forward slashes to match what the server expects.
-        path = path.gsub(/%2F/, '/')
-        # Unencode the backward slashes to match what the server expects.
-        path = path.gsub(/%5C/, '/')
-        # Re-encode the spaces (encoded as space) to the % encoding.
-        path = path.gsub(/\+/, '%20')
-
         generate_uri(path, query)
       end
       

--- a/lib/azure/storage/blob/block.rb
+++ b/lib/azure/storage/blob/block.rb
@@ -115,6 +115,7 @@ module Azure::Storage
 
       result = Serialization.blob_from_headers(response.headers)
       result.name = blob
+      result.metadata = options[:metadata] if options[:metadata]
 
       result
     end

--- a/lib/azure/storage/blob/page.rb
+++ b/lib/azure/storage/blob/page.rb
@@ -118,12 +118,14 @@ module Azure::Storage
     # * +blob+                       - String. Name of blob
     # * +start_range+                - Integer. Position of first byte of first page
     # * +end_range+                  - Integer. Position of last byte of of last page
-    # * +content+                    - IO or String. Content to write. Length in bytes should equal end_range - start_range
+    # * +content+                    - IO or String. Content to write. Length in bytes should equal end_range - start_range + 1
     # * +options+                    - Hash. A collection of options.
     #
     # ==== Options
     #
     # Accepted key/value pairs in options parameter are:
+    # * +:transactional_md5+         - String. An MD5 hash of the page content. This hash is used to verify the integrity of the page during transport.
+    #                                  When this header is specified, the storage service checks the hash that has arrived with the one that was sent.
     # * +:if_sequence_number_le+     - Integer. If the blob's sequence number is less than or equal to the specified value, the request proceeds; 
     #                                  otherwise it fails with the SequenceNumberConditionNotMet error (HTTP status code 412 - Precondition Failed).
     # * +:if_sequence_number_lt+     - Integer. If the blob's sequence number is less than the specified value, the request proceeds; 
@@ -155,6 +157,7 @@ module Azure::Storage
 
       uri = blob_uri(container, blob, query)
       headers = StorageService.common_headers
+      StorageService.with_header headers, 'Content-MD5', options[:transactional_md5]
       StorageService.with_header headers, 'x-ms-range', "bytes=#{start_range}-#{end_range}"
       StorageService.with_header headers, 'x-ms-page-write', 'update'
 

--- a/lib/azure/storage/blob/page.rb
+++ b/lib/azure/storage/blob/page.rb
@@ -106,7 +106,8 @@ module Azure::Storage
 
       result = Serialization.blob_from_headers(response.headers)
       result.name = blob
-
+      result.metadata = options[:metadata] if options[:metadata]
+      
       result
     end
     

--- a/lib/azure/storage/client.rb
+++ b/lib/azure/storage/client.rb
@@ -31,6 +31,7 @@ require 'azure/storage/service/storage_service'
 require 'azure/storage/blob/blob_service'
 require 'azure/storage/table/table_service'
 require 'azure/storage/queue/queue_service'
+require 'azure/storage/file/file_service'
 
 module Azure::Storage
   class Client
@@ -108,6 +109,12 @@ module Azure::Storage
     # @return [Azure::Storage::Table::TableService]
     def table_client(options = {})
       @table_client ||= Azure::Storage::Table::TableService.new(default_client(options))
+    end
+
+    # Azure File service client configured from this Azure Storage client instance
+    # @return [Azure::Storage::File::FileService]
+    def file_client(options = {})
+      @file_client ||= Azure::Storage::File::FileService.new(default_client(options))
     end
 
     class << self

--- a/lib/azure/storage/client.rb
+++ b/lib/azure/storage/client.rb
@@ -51,6 +51,7 @@ module Azure::Storage
     #
     # * +:use_development_storage+        - True. Whether to use storage emulator.
     # * +:development_storage_proxy_uri+  - String. Used with +:use_development_storage+ if emulator is hosted other than localhost.
+    # * +:storage_connection_string+      - String. The storage connection string.
     # * +:storage_account_name+           - String. The name of the storage account.
     # * +:storage_access_key+             - Base64 String. The access key of the storage account.
     # * +:storage_sas_token+              - String. The signed access signiture for the storage account or one of its service.
@@ -80,14 +81,9 @@ module Azure::Storage
     #
     # @return [Azure::Storage::Client]
     def initialize(options = {}, &block)
-      if options.is_a?(Hash)
-        options = setup_options if options.length == 0
-        options = parse_connection_string(options[:storage_connection_string]) if options[:storage_connection_string]
-
-        if options.has_key?(:user_agent_prefix)
-          Azure::Storage::Service::StorageService.user_agent_prefix = options[:user_agent_prefix]
-          options.delete :user_agent_prefix
-        end
+      if options.is_a?(Hash) and options.has_key?(:user_agent_prefix)
+        Azure::Storage::Service::StorageService.user_agent_prefix = options[:user_agent_prefix]
+        options.delete :user_agent_prefix
       end
       Azure::Storage::Service::StorageService.register_request_callback &block if block_given?
       reset!(options)

--- a/lib/azure/storage/client_options.rb
+++ b/lib/azure/storage/client_options.rb
@@ -34,7 +34,7 @@ module Azure::Storage
     #
     # ==== Attributes
     #
-    # * +options+    - Hash. Optional parameters.
+    # * +options+                         - Hash | String. Optional parameters or storage connection string.
     #
     # ==== Options
     #
@@ -42,6 +42,7 @@ module Azure::Storage
     #
     # * +:use_development_storage+        - TrueClass. Whether to use storage emulator.
     # * +:development_storage_proxy_uri+  - String. Used with +:use_development_storage+ if emulator is hosted other than localhost.
+    # * +:storage_connection_string+      - String. The storage connection string.
     # * +:storage_account_name+           - String. The name of the storage account.
     # * +:storage_access_key+             - Base64 String. The access key of the storage account.
     # * +:storage_sas_token+              - String. The signed access signiture for the storage account or one of its service.
@@ -71,9 +72,16 @@ module Azure::Storage
     def reset!(options = {})
       if options.is_a? String
         options = parse_connection_string(options)
+      elsif options.is_a? Hash
+        # When the options are provided via singlton setup: Azure::Storage.setup()
+        options = setup_options if options.length == 0
+        
+        options = parse_connection_string(options[:storage_connection_string]) if options[:storage_connection_string]
       end
-      
+
+      # Load from environment when no valid input
       options = load_env if options.length == 0
+
       @ca_file = options.delete(:ca_file)
       @options = filter(options)
       self.send(:reset_config!, @options) if self.respond_to?(:reset_config!)

--- a/lib/azure/storage/core/auth/shared_access_signature_generator.rb
+++ b/lib/azure/storage/core/auth/shared_access_signature_generator.rb
@@ -83,6 +83,15 @@ module Azure::Storage::Core
         endrk:                :erk
       }
 
+      FILE_KEY_MAPPINGS = {
+        resource:             :sr,
+        cache_control:        :rscc,
+        content_disposition:  :rscd,
+        content_encoding:     :rsce,
+        content_language:     :rscl,
+        content_type:         :rsct
+      }
+
       SERVICE_OPTIONAL_QUERY_PARAMS = [:sp, :si, :sip, :spr, :rscc, :rscd, :rsce, :rscl, :rsct, :spk, :srk, :epk, :erk]
 
       ACCOUNT_OPTIONAL_QUERY_PARAMS = [:st, :sip, :spr]
@@ -151,6 +160,13 @@ module Azure::Storage::Core
         elsif service_type == Azure::Storage::ServiceType::TABLE
           options.merge!(table_name: path)
           valid_mappings.merge!(TABLE_KEY_MAPPINGS)
+        elsif service_type == Azure::Storage::ServiceType::FILE
+          if options[:resource]
+            options.merge!(resource: options[:resource])
+          else
+            options.merge!(resource: 'f')
+          end
+          valid_mappings.merge!(FILE_KEY_MAPPINGS)
         end
 
         invalid_options = options.reject { |k, _| valid_mappings.key?(k) }
@@ -188,7 +204,7 @@ module Azure::Storage::Core
           options[:content_encoding],
           options[:content_language],
           options[:content_type]
-        ] if service_type == Azure::Storage::ServiceType::BLOB
+        ] if service_type == Azure::Storage::ServiceType::BLOB || service_type == Azure::Storage::ServiceType::FILE
 
         signable_fields.concat [
           options[:startpk],

--- a/lib/azure/storage/file/directory.rb
+++ b/lib/azure/storage/file/directory.rb
@@ -1,0 +1,268 @@
+#-------------------------------------------------------------------------
+# # Copyright (c) Microsoft and contributors. All rights reserved.
+#
+# The MIT License(MIT)
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#--------------------------------------------------------------------------
+require 'azure/storage/file/serialization'
+
+module Azure::Storage::File
+  module Directory
+    include Azure::Storage::Service
+    
+    class Directory
+      def initialize
+        @properties = {}
+        @metadata = {}
+        yield self if block_given?
+      end
+
+      attr_accessor :name
+      attr_accessor :properties
+      attr_accessor :metadata
+    end
+  end
+
+  # Public: Get a list of files or directories under the specified share or directory.
+  #         It lists the contents only for a single level of the directory hierarchy.
+  #
+  # ==== Attributes
+  #
+  # * +share+                     - String. The name of the file share.
+  # * +directory_path+            - String. The path to the directory.
+  # * +options+                   - Hash. Optional parameters.
+  #
+  # ==== Options
+  #
+  # Accepted key/value pairs in options parameter are:
+  #
+  # * +:marker+                  - String. An identifier the specifies the portion of the
+  #                                list to be returned. This value comes from the property
+  #                                Azure::Service::EnumerationResults.continuation_token when there
+  #                                are more shares available than were returned. The
+  #                                marker value may then be used here to request the next set
+  #                                of list items. (optional)
+  #
+  # * +:max_results+             - Integer. Specifies the maximum number of shares to return.
+  #                                If max_results is not specified, or is a value greater than
+  #                                5,000, the server will return up to 5,000 items. If it is set
+  #                                to a value less than or equal to zero, the server will return
+  #                                status code 400 (Bad Request). (optional)
+  #
+  # * +:timeout+                 - Integer. A timeout in seconds.
+  #
+  # * +:request_id+              - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+  #                                in the analytics logs when storage analytics logging is enabled.
+  #
+  # See: https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/list-directories-and-files
+  #
+  # Returns an Azure::Service::EnumerationResults
+  #
+  def list_directories_and_files(share, directory_path, options={})
+    query = {'comp' => 'list'}
+    unless options.nil?
+      StorageService.with_query query, 'marker', options[:marker]
+      StorageService.with_query query, 'maxresults', options[:max_results].to_s if options[:max_results]
+      StorageService.with_query query, 'timeout', options[:timeout].to_s if options[:timeout]
+    end
+
+    uri = directory_uri(share, directory_path, query)
+    response = call(:get, uri, nil, {}, options)
+
+    # Result
+    if response.success?
+      Serialization.directories_and_files_enumeration_results_from_xml(response.body)
+    else
+      response.exception
+    end
+  end
+
+  # Public: Create a new directory
+  #
+  # ==== Attributes
+  #
+  # * +share+                     - String. The name of the file share.
+  # * +directory_path+            - String. The path to the directory.
+  # * +options+                   - Hash. Optional parameters.
+  #
+  # ==== Options
+  #
+  # Accepted key/value pairs in options parameter are:
+  # * +:metadata+                 - Hash. User defined metadata for the share (optional).
+  # * +:timeout+                  - Integer. A timeout in seconds.
+  # * +:request_id+               - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+  #                                 in the analytics logs when storage analytics logging is enabled.
+  #
+  # See https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/create-directory
+  #
+  # Returns a Directory
+  def create_directory(share, directory_path, options={})
+    # Query
+    query = { }
+    query['timeout'] = options[:timeout].to_s if options[:timeout]
+
+    # Scheme + path
+    uri = directory_uri(share, directory_path, query)
+
+    # Headers
+    headers = StorageService.common_headers
+    StorageService.add_metadata_to_headers(options[:metadata], headers) if options[:metadata]
+
+    # Call
+    response = call(:put, uri, nil, headers, options)
+
+    # result
+    directory = Serialization.directory_from_headers(response.headers)
+    directory.name = directory_path
+    directory.metadata = options[:metadata] if options[:metadata]
+    directory
+  end
+
+  # Public: Returns all system properties for the specified directory,
+  #         and can also be used to check the existence of a directory.
+  #         The data returned does not include the files in the directory or any subdirectories.
+  #
+  # ==== Attributes
+  #
+  # * +share+                     - String. The name of the file share.
+  # * +directory_path+            - String. The path to the directory.
+  # * +options+                   - Hash. Optional parameters.
+  #
+  # ==== Options
+  #
+  # Accepted key/value pairs in options parameter are:
+  # * +:timeout+                  - Integer. A timeout in seconds.
+  # * +:request_id+               - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+  #                                 in the analytics logs when storage analytics logging is enabled.
+  #
+  # See https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/get-directory-properties
+  #
+  # Returns a Directory
+  def get_directory_properties(share, directory_path, options={})
+    # Query
+    query = { }
+    query['timeout'] = options[:timeout].to_s if options[:timeout]
+
+    # Call
+    response = call(:get, directory_uri(share, directory_path, query), nil, {}, options)
+
+    # result
+    directory = Serialization.directory_from_headers(response.headers)
+    directory.name = directory_path
+    directory
+  end
+
+  # Public: Deletes a directory.
+  #
+  # ==== Attributes
+  #
+  # * +share+                     - String. The name of the file share.
+  # * +directory_path+            - String. The path to the directory.
+  # * +options+                   - Hash. Optional parameters.
+  #
+  # ==== Options
+  #
+  # Accepted key/value pairs in options parameter are:
+  # * +:timeout+                  - Integer. A timeout in seconds.
+  # * +:request_id+               - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+  #                                 in the analytics logs when storage analytics logging is enabled.
+  #
+  # See https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/delete-directory
+  #
+  # Returns nil on success
+  def delete_directory(share, directory_path, options={})
+    # Query
+    query = { }
+    query['timeout'] = options[:timeout].to_s if options[:timeout]
+
+    # Call
+    call(:delete, directory_uri(share, directory_path, query), nil, {}, options)
+    
+    # result
+    nil
+  end
+
+  # Public: Returns only user-defined metadata for the specified directory.
+  #
+  # ==== Attributes
+  #
+  # * +share+                     - String. The name of the file share.
+  # * +directory_path+            - String. The path to the directory.
+  # * +options+                   - Hash. Optional parameters.
+  #
+  # ==== Options
+  #
+  # Accepted key/value pairs in options parameter are:
+  # * +:timeout+                  - Integer. A timeout in seconds.
+  # * +:request_id+               - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+  #                                 in the analytics logs when storage analytics logging is enabled.
+  #
+  # See https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/get-directory-metadata
+  #
+  # Returns a Directory
+  def get_directory_metadata(share, directory_path, options={})
+    # Query
+    query = { 'comp' => 'metadata' }
+    query['timeout'] = options[:timeout].to_s if options[:timeout]
+
+    # Call
+    response = call(:get, directory_uri(share, directory_path, query), nil, {}, options)
+
+    # result
+    directory = Serialization.directory_from_headers(response.headers)
+    directory.name = directory_path
+    directory
+  end
+
+  # Public: Sets custom metadata for the directory.
+  #
+  # ==== Attributes
+  #
+  # * +share+                     - String. The name of the file share.
+  # * +directory_path+            - String. The path to the directory.
+  # * +metadata+                  - Hash. A Hash of the metadata values.
+  # * +options+                   - Hash. Optional parameters.
+  #
+  # ==== Options
+  #
+  # Accepted key/value pairs in options parameter are:
+  # * +:timeout+                  - Integer. A timeout in seconds.
+  # * +:request_id+               - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+  #                                 in the analytics logs when storage analytics logging is enabled.
+  #
+  # See https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/set-directory-metadata
+  #
+  # Returns nil on success
+  def set_directory_metadata(share, directory_path, metadata, options={})
+    # Query
+    query = { 'comp' => 'metadata' }
+    query['timeout'] = options[:timeout].to_s if options[:timeout]
+
+    # Headers
+    headers = StorageService.common_headers
+    StorageService.add_metadata_to_headers(metadata, headers) if metadata
+
+    # Call
+    call(:put, directory_uri(share, directory_path, query), nil, headers, options)
+    
+    # Result
+    nil
+  end
+end

--- a/lib/azure/storage/file/file.rb
+++ b/lib/azure/storage/file/file.rb
@@ -1,0 +1,602 @@
+#-------------------------------------------------------------------------
+# # Copyright (c) Microsoft and contributors. All rights reserved.
+#
+# The MIT License(MIT)
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#--------------------------------------------------------------------------
+require 'azure/storage/file/serialization'
+
+module Azure::Storage::File
+  include Azure::Storage::Service
+    
+  class File
+    def initialize
+      @properties = {}
+      @metadata = {}
+      yield self if block_given?
+    end
+
+    attr_accessor :name
+    attr_accessor :properties
+    attr_accessor :metadata
+  end
+
+  # Public: Creates a new file or replaces a file. Note that it only initializes the file.
+  #         To add content to a file, call the put_range operation.
+  #
+  # Updating an existing file overwrites any existing metadata on the file
+  # Partial updates are not supported with create_file. The content of the
+  # existing file is overwritten with the content of the new file. To perform a
+  # partial update of the content of a file, use the put_range method.
+  #
+  # Note that the default content type is application/octet-stream.
+  #
+  # ==== Attributes
+  #
+  # * +share+                      - String. The name of the file share.
+  # * +directory_path+             - String. The path to the directory.
+  # * +file+                       - String. The name of the file.
+  # * +length+                     - Integer. Specifies the maximum byte value for the file, up to 1 TB.
+  # * +options+                    - Hash. Optional parameters.
+  #
+  # ==== Options
+  #
+  # Accepted key/value pairs in options parameter are:
+  # * +:content_type+              - String. Content type for the file. Will be saved with file.
+  # * +:content_encoding+          - String. Content encoding for the file. Will be saved with file.
+  # * +:content_language+          - String. Content language for the file. Will be saved with file.
+  # * +:content_md5+               - String. Content MD5 for the file. Will be saved with file.
+  # * +:cache_control+             - String. Cache control for the file. Will be saved with file.
+  # * +:content_disposition+       - String. Conveys additional information about how to process the response payload, 
+  #                                  and also can be used to attach additional metadata
+  # * +:metadata+                  - Hash. Custom metadata values to store with the file.
+  # * +:timeout+                   - Integer. A timeout in seconds.
+  # * +:request_id+                - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+  #                                  in the analytics logs when storage analytics logging is enabled.
+  #
+  # See https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/create-file
+  #
+  # Returns a File
+  def create_file(share, directory_path, file, length, options={})
+    query = { }
+    StorageService.with_query query, 'timeout', options[:timeout].to_s if options[:timeout]
+
+    uri = file_uri(share, directory_path, file, query)
+
+    headers = StorageService.common_headers
+
+    # set x-ms-type to file
+    StorageService.with_header headers, 'x-ms-type', 'file'
+
+    # ensure content-length is 0 and x-ms-content-length is the file length
+    StorageService.with_header headers, 'Content-Length', 0.to_s
+    StorageService.with_header headers, 'x-ms-content-length', length.to_s
+
+    # set the rest of the optional headers
+    StorageService.with_header headers, 'x-ms-content-type', options[:content_type]
+    StorageService.with_header headers, 'x-ms-content-encoding', options[:content_encoding]
+    StorageService.with_header headers, 'x-ms-content-language', options[:content_language]
+    StorageService.with_header headers, 'x-ms-content-md5', options[:content_md5]
+    StorageService.with_header headers, 'x-ms-cache-control', options[:cache_control]
+    StorageService.with_header headers, 'x-ms-content-disposition', options[:content_disposition]
+
+    StorageService.add_metadata_to_headers options[:metadata], headers
+
+    response = call(:put, uri, nil, headers, options)
+
+    result = Serialization.file_from_headers(response.headers)
+    result.name = file
+    result.properties[:content_length] = length
+    result.metadata = options[:metadata] if options[:metadata]
+    result
+  end
+
+  # Public: Reads or downloads a file from the system, including its metadata and properties.
+  #
+  # ==== Attributes
+  #
+  # * +share+                      - String. The name of the file share.
+  # * +directory_path+             - String. The path to the directory.
+  # * +file+                       - String. The name of the file.
+  # * +options+                    - Hash. Optional parameters.
+  #
+  # ==== Options
+  #
+  # Accepted key/value pairs in options parameter are:
+  # * +:start_range+               - Integer. Position of the start range. (optional)
+  # * +:end_range+                 - Integer. Position of the end range. (optional)
+  # * +:get_content_md5+           - Boolean. Return the MD5 hash for the range. This option only valid if
+  #                                  start_range and end_range are specified. (optional)
+  # * +:timeout+                   - Integer. A timeout in seconds.
+  # * +:request_id+                - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+  #                                  in the analytics logs when storage analytics logging is enabled.
+  #
+  # See https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/get-file
+  #
+  # Returns a File and the file body
+  def get_file(share, directory_path, file, options={})
+    query = { }
+    StorageService.with_query query, 'timeout', options[:timeout].to_s if options[:timeout]
+    uri = file_uri(share, directory_path, file, query)
+
+    headers = StorageService.common_headers
+    options[:start_range] = 0 if options[:end_range] and not options[:start_range]
+    if options[:start_range]
+      StorageService.with_header headers, 'x-ms-range', "bytes=#{options[:start_range]}-#{options[:end_range]}"
+      StorageService.with_header headers, 'x-ms-range-get-content-md5', true if options[:get_content_md5]
+    end
+
+    response = call(:get, uri, nil, headers, options)
+    result = Serialization.file_from_headers(response.headers)
+    result.name = file
+    return result, response.body
+  end
+
+  # Public: Returns all properties and metadata on the file.
+  #
+  # ==== Attributes
+  #
+  # * +share+                      - String. The name of the file share.
+  # * +directory_path+             - String. The path to the directory.
+  # * +file+                       - String. The name of the file.
+  # * +options+                    - Hash. Optional parameters.
+  #
+  # ==== Options
+  #
+  # Accepted key/value pairs in options parameter are:
+  # * +:timeout+                   - Integer. A timeout in seconds.
+  # * +:request_id+                - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+  #                                  in the analytics logs when storage analytics logging is enabled.
+  #
+  # See https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/get-file-properties
+  #
+  # Returns a File
+  def get_file_properties(share, directory_path, file, options={})
+    query = { }
+    StorageService.with_query query, 'timeout', options[:timeout].to_s if options[:timeout]
+
+    headers = StorageService.common_headers
+      
+    uri = file_uri(share, directory_path, file, query)
+
+    response = call(:head, uri, nil, headers, options)
+
+    result = Serialization.file_from_headers(response.headers)
+    result.name = file
+    result
+  end
+
+  # Public: Sets system properties defined for a file.
+  #
+  # ==== Attributes
+  #
+  # * +share+                      - String. The name of the file share.
+  # * +directory_path+             - String. The path to the directory.
+  # * +file+                       - String. The name of the file.
+  # * +options+                    - Hash. Optional parameters.
+  #
+  # ==== Options
+  #
+  # Accepted key/value pairs in options parameter are:
+  # * +:content_type+              - String. Content type for the file. Will be saved with file.
+  # * +:content_encoding+          - String. Content encoding for the file. Will be saved with file.
+  # * +:content_language+          - String. Content language for the file. Will be saved with file.
+  # * +:content_md5+               - String. Content MD5 for the file. Will be saved with file.
+  # * +:cache_control+             - String. Cache control for the file. Will be saved with file.
+  # * +:content_disposition+       - String. Conveys additional information about how to process the response payload, 
+  #                                  and also can be used to attach additional metadata
+  # * +:content_length+            - Integer. Resizes a file to the specified size. If the specified
+  #                                  value is less than the current size of the file, then all ranges above
+  #                                  the specified value are cleared.
+  # * +:timeout+                   - Integer. A timeout in seconds.
+  # * +:request_id+                - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+  #                                  in the analytics logs when storage analytics logging is enabled.
+  #
+  # See https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/set-file-properties
+  #
+  # Returns nil on success.
+  def set_file_properties(share, directory_path, file, options={})
+    query = {'comp' => 'properties'}
+    StorageService.with_query query, 'timeout', options[:timeout].to_s if options[:timeout]
+    uri = file_uri(share, directory_path, file, query)
+
+    headers = StorageService.common_headers
+
+    unless options.empty?
+      StorageService.with_header headers, 'x-ms-content-type', options[:content_type]
+      StorageService.with_header headers, 'x-ms-content-encoding', options[:content_encoding]
+      StorageService.with_header headers, 'x-ms-content-language', options[:content_language]
+      StorageService.with_header headers, 'x-ms-content-md5', options[:content_md5]
+      StorageService.with_header headers, 'x-ms-cache-control', options[:cache_control]
+      StorageService.with_header headers, 'x-ms-content-length', options[:content_length].to_s if options[:content_length]
+      StorageService.with_header headers, 'x-ms-content-disposition', options[:content_disposition]
+    end
+
+    call(:put, uri, nil, headers, options)
+    nil
+  end
+
+  # Public: Resizes a file to the specified size.
+  #
+  # ==== Attributes
+  #
+  # * +share+                      - String. The name of the file share.
+  # * +directory_path+             - String. The path to the directory.
+  # * +file+                       - String. The name of the file.
+  # * +size+                       - String. The file size. Resizes a file to the specified size. 
+  #                                  If the specified value is less than the current size of the file, 
+  #                                  then all ranges above the specified value are cleared.
+  # * +options+                    - Hash. Optional parameters.
+  #
+  # ==== Options
+  #
+  # Accepted key/value pairs in options parameter are:
+  # * +:timeout+                   - Integer. A timeout in seconds.
+  # * +:request_id+                - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+  #                                  in the analytics logs when storage analytics logging is enabled.
+  #
+  # See https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/set-file-properties
+  #
+  # Returns nil on success.
+  def resize_file(share, directory_path, file, size, options={})
+    options = { :content_length => size }.merge(options)
+    set_file_properties share, directory_path, file, options
+  end
+
+  # Public: Writes a range of bytes to a file
+  #
+  # ==== Attributes
+  #
+  # * +share+                      - String. The name of the file share.
+  # * +directory_path+             - String. The path to the directory.
+  # * +file+                       - String. The name of the file.
+  # * +start_range+                - Integer. Position of first byte of the range.
+  # * +end_range+                  - Integer. Position of last byte of of the range. The range can be up to 4 MB in size.
+  # * +content+                    - IO or String. Content to write.
+  # * +options+                    - Hash. A collection of options.
+  #
+  # ==== Options
+  #
+  # Accepted key/value pairs in options parameter are:
+  # * +:transactional_md5+         - String. An MD5 hash of the content. This hash is used to verify the integrity of the data during transport.
+  #                                  When this header is specified, the storage service checks the hash that has arrived with the one that was sent.
+  # * +:timeout+                   - Integer. A timeout in seconds.
+  # * +:request_id+                - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+  #                                  in the analytics logs when storage analytics logging is enabled.
+  # 
+  # See https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/put-range
+  #
+  # Returns a File
+  #
+  def put_file_range(share, directory_path, file, start_range, end_range=nil, content=nil, options={})
+    query = { 'comp' => 'range' }
+    StorageService.with_query query, 'timeout', options[:timeout].to_s if options[:timeout]
+
+    uri = file_uri(share, directory_path, file, query)
+    headers = StorageService.common_headers
+    StorageService.with_header headers, 'Content-MD5', options[:transactional_md5]
+    StorageService.with_header headers, 'x-ms-range', "bytes=#{start_range}-#{end_range}"
+    StorageService.with_header headers, 'x-ms-write', 'update'
+    
+    response = call(:put, uri, content, headers, options)
+
+    result = Serialization.file_from_headers(response.headers)
+    result.name = file
+    result
+  end
+
+  # Public: Clears a range of file.
+  #
+  # ==== Attributes
+  #
+  # * +share+                      - String. The name of the file share.
+  # * +directory_path+             - String. The path to the directory.
+  # * +file+                       - String. The name of the file.
+  # * +start_range+                - Integer. Position of first byte of the range.
+  # * +end_range+                  - Integer. Position of last byte of of the range.
+  # * +options+                    - Hash. A collection of options.
+  #
+  # ==== Options
+  #
+  # Accepted key/value pairs in options parameter are:
+  # * +:timeout+                   - Integer. A timeout in seconds.
+  # * +:request_id+                - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+  #                                  in the analytics logs when storage analytics logging is enabled.
+  #
+  # See https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/put-range
+  #
+  # Returns a File
+  def clear_file_range(share, directory_path, file, start_range, end_range=nil, options={})
+    query = { 'comp' => 'range' }
+    StorageService.with_query query, 'timeout', options[:timeout].to_s if options[:timeout]
+
+    uri =  file_uri(share, directory_path, file, query)
+    start_range = 0 if !end_range.nil? and start_range.nil?
+
+    headers = StorageService.common_headers
+    StorageService.with_header headers, 'x-ms-range', "bytes=#{start_range}-#{end_range}"
+    StorageService.with_header headers, 'x-ms-write', 'clear'
+
+    response = call(:put, uri, nil, headers, options)
+
+    result = Serialization.file_from_headers(response.headers)
+    result.name = file
+    result
+  end
+
+  # Public: Returns a list of valid ranges for a file.
+  #
+  # ==== Attributes
+  #
+  # * +share+                      - String. The name of the file share.
+  # * +directory_path+             - String. The path to the directory.
+  # * +file+                       - String. The name of the file.
+  # * +options+                    - Hash. Optional parameters.
+  #
+  # ==== Options
+  #
+  # Accepted key/value pairs in options parameter are:
+  # * +:start_range+               - Integer. Position of first byte of the range.
+  # * +:end_range+                 - Integer. Position of last byte of of the range.
+  # * +:timeout+                   - Integer. A timeout in seconds.
+  # * +:request_id+                - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+  #                                  in the analytics logs when storage analytics logging is enabled.
+  #
+  # See https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/list-ranges
+  #
+  # Returns a tuple of a File and a list of ranges in the format [ [start, end], [start, end], ... ]
+  #
+  #   eg. (Azure::Storage::File::File, [ [0, 511], [512, 1024], ... ])
+  #
+  def list_file_ranges(share, directory_path, file, options={})
+    query = {'comp' => 'rangelist'}
+    StorageService.with_query query, 'timeout', options[:timeout].to_s if options[:timeout]
+
+    uri = file_uri(share, directory_path, file, query)
+
+    options[:start_range] = 0 if options[:end_range] and not options[:start_range]
+
+    headers = StorageService.common_headers
+    StorageService.with_header headers, 'x-ms-range', "bytes=#{options[:start_range]}-#{options[:end_range]}" if options[:start_range]
+    
+    response = call(:get, uri, nil, headers, options)
+
+    result = Serialization.file_from_headers(response.headers)
+    result.name = file
+    rangelist = Serialization.range_list_from_xml(response.body)
+    return result, rangelist
+  end
+
+  # Public: Returns only user-defined metadata for the specified file.
+  #
+  # ==== Attributes
+  #
+  # * +share+                     - String. The name of the file share.
+  # * +directory_path+            - String. The path to the directory.
+  # * +file+                      - String. The name of the file.
+  # * +options+                   - Hash. Optional parameters.
+  #
+  # ==== Options
+  #
+  # Accepted key/value pairs in options parameter are:
+  # * +:timeout+                  - Integer. A timeout in seconds.
+  # * +:request_id+               - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+  #                                 in the analytics logs when storage analytics logging is enabled.
+  #
+  # See https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/get-file-metadata
+  #
+  # Returns a File
+  def get_file_metadata(share, directory_path, file, options={})
+    # Query
+    query = { 'comp' => 'metadata' }
+    query['timeout'] = options[:timeout].to_s if options[:timeout]
+
+    # Call
+    response = call(:get, file_uri(share, directory_path, file, query), nil, {}, options)
+
+    # result
+    result = Serialization.file_from_headers(response.headers)
+    result.name = file
+    result
+  end
+
+  # Public: Sets custom metadata for the file.
+  #
+  # ==== Attributes
+  #
+  # * +share+                     - String. The name of the file share.
+  # * +directory_path+            - String. The path to the directory.
+  # * +file+                      - String. The name of the file.
+  # * +metadata+                  - Hash. A Hash of the metadata values.
+  # * +options+                   - Hash. Optional parameters.
+  #
+  # ==== Options
+  #
+  # Accepted key/value pairs in options parameter are:
+  # * +:timeout+                  - Integer. A timeout in seconds.
+  # * +:request_id+               - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+  #                                 in the analytics logs when storage analytics logging is enabled.
+  #
+  # See https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/set-file-metadata
+  #
+  # Returns nil on success
+  def set_file_metadata(share, directory_path, file, metadata, options={})
+    # Query
+    query = { 'comp' => 'metadata' }
+    query['timeout'] = options[:timeout].to_s if options[:timeout]
+
+    # Headers
+    headers = StorageService.common_headers
+    StorageService.add_metadata_to_headers(metadata, headers) if metadata
+
+    # Call
+    call(:put, file_uri(share, directory_path, file, query), nil, headers, options)
+    
+    # Result
+    nil
+  end
+
+  # Public: Deletes a file.
+  #
+  # ==== Attributes
+  #
+  # * +share+                     - String. The name of the file share.
+  # * +directory_path+            - String. The path to the directory.
+  # * +file+                      - String. The name of the file.
+  # * +options+                   - Hash. Optional parameters.
+  #
+  # ==== Options
+  #
+  # Accepted key/value pairs in options parameter are:
+  # * +:timeout+                  - Integer. A timeout in seconds.
+  # * +:request_id+               - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+  #                                 in the analytics logs when storage analytics logging is enabled.
+  #
+  # See https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/delete-file2
+  #
+  # Returns nil on success
+  def delete_file(share, directory_path, file, options={})
+    # Query
+    query = { }
+    query['timeout'] = options[:timeout].to_s if options[:timeout]
+    
+    # Call
+    call(:delete, file_uri(share, directory_path, file, query), nil, {}, options)
+    
+    # result
+    nil
+  end
+
+  # Public: Copies a source file or file to a destination file within the storage account.
+  #
+  # ==== Attributes
+  #
+  # * +destination_share+             - String. The name of the destination file share.
+  # * +destination_directory_path+    - String. The path to the destination directory.
+  # * +destination_file+              - String. The name of the destination file.
+  # * +source_uri+                    - String. The source file or file URI to copy from.
+  # * +options+                       - Hash. Optional parameters.
+  #
+  # ==== Options
+  #
+  # Accepted key/value pairs in options parameter are:
+  # * +:metadata+                   - Hash. Custom metadata values to store with the copy. If this parameter is not
+  #                                   specified, the operation will copy the source file metadata to the destination
+  #                                   file. If this parameter is specified, the destination file is created with the
+  #                                   specified metadata, and metadata is not copied from the source file.
+  # * +:timeout+                    - Integer. A timeout in seconds.
+  # * +:request_id+                 - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+  #                                   in the analytics logs when storage analytics logging is enabled.
+  #
+  # See https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/copy-file
+  #
+  # Returns a tuple of (copy_id, copy_status).
+  #
+  # * +copy_id+                    - String identifier for this copy operation. Use with get_file or get_file_properties to check
+  #                                  the status of this copy operation, or pass to abort_copy_file to abort a pending copy.
+  # * +copy_status+                - String. The state of the copy operation, with these values:
+  #                                    "success" - The copy completed successfully.
+  #                                    "pending" - The copy is in progress.
+  #
+  def copy_file_from_uri(destination_share, destination_directory_path, destination_file, source_uri, options={})
+    query = { }
+    StorageService.with_query query, 'timeout', options[:timeout].to_s if options[:timeout]
+
+    uri = file_uri(destination_share, destination_directory_path, destination_file, query)
+    headers = StorageService.common_headers
+    StorageService.with_header headers, 'x-ms-copy-source', source_uri
+    StorageService.add_metadata_to_headers options[:metadata], headers unless options.empty?
+
+    response = call(:put, uri, nil, headers, options)
+    return response.headers['x-ms-copy-id'], response.headers['x-ms-copy-status']
+  end
+
+  # Public: Copies a source file to a destination file within the same storage account.
+  #
+  # ==== Attributes
+  #
+  # * +destination_share+             - String. The destination share name to copy to.
+  # * +destination_directory_path+    - String. The path to the destination directory.
+  # * +source_file+                   - String. The destination file name to copy to.
+  # * +source_share+                  - String. The source share name to copy from.
+  # * +source_directory_path+         - String. The path to the source directory.
+  # * +source_file+                   - String. The source file name to copy from.
+  # * +options+                       - Hash. Optional parameters.
+  #
+  # ==== Options
+  #
+  # Accepted key/value pairs in options parameter are:
+  # * +:metadata+                   - Hash. Custom metadata values to store with the copy. If this parameter is not
+  #                                   specified, the operation will copy the source file metadata to the destination
+  #                                   file. If this parameter is specified, the destination file is created with the
+  #                                   specified metadata, and metadata is not copied from the source file.
+  # * +:timeout+                    - Integer. A timeout in seconds.
+  # * +:request_id+                 - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+  #                                   in the analytics logs when storage analytics logging is enabled.
+  #
+  # See https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/copy-file
+  #
+  # Returns a tuple of (copy_id, copy_status).
+  #
+  # * +copy_id+                    - String identifier for this copy operation. Use with get_file or get_file_properties to check
+  #                                  the status of this copy operation, or pass to abort_copy_file to abort a pending copy.
+  # * +copy_status+                - String. The state of the copy operation, with these values:
+  #                                    "success" - The copy completed successfully.
+  #                                    "pending" - The copy is in progress.
+  #
+  def copy_file(destination_share, destination_directory_path, destination_file, source_share, source_directory_path, source_file, options={})
+    source_file_uri = file_uri(source_share, source_directory_path, source_file, {}).to_s
+
+    return copy_file_from_uri(destination_share, destination_directory_path, destination_file, source_file_uri, options)
+  end
+
+  # Public: Aborts a pending Copy File operation and leaves a destination file with zero length and full metadata. 
+  #
+  # ==== Attributes
+  #
+  # * +share+                 - String. The name of the destination file share.
+  # * +directory_path+        - String. The path to the destination directory.
+  # * +file+                  - String. The name of the destination file.
+  # * +copy_id+               - String. The copy identifier returned in the copy file operation.
+  # * +options+               - Hash. Optional parameters.
+  #
+  # ==== Options
+  #
+  # Accepted key/value pairs in options parameter are:
+  # * +:timeout+              - Integer. A timeout in seconds.
+  # * +:request_id+           - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+  #                             in the analytics logs when storage analytics logging is enabled.
+  #
+  # See https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/abort-copy-file
+  #
+  # Returns nil on success
+  def abort_copy_file(share, directory_path, file, copy_id, options={})
+    query = {'comp' => 'copy'}
+    StorageService.with_query query, 'timeout', options[:timeout].to_s if options[:timeout]
+    StorageService.with_query query, 'copyid', copy_id
+
+    uri = file_uri(share, directory_path, file, query);
+    headers = StorageService.common_headers
+    StorageService.with_header headers, 'x-ms-copy-action', 'abort';
+
+    call(:put, uri, nil, headers, options)
+    nil
+  end
+end

--- a/lib/azure/storage/file/file_service.rb
+++ b/lib/azure/storage/file/file_service.rb
@@ -35,7 +35,7 @@ module Azure::Storage
 
       def initialize(options = {}, &block)
         client_config = options[:client] || Azure::Storage
-        signer = options[:signer] || Core::Auth::SharedKey.new(client_config.storage_account_name, client_config.storage_access_key)
+        signer = options[:signer] || client_config.signer || Core::Auth::SharedKey.new(client_config.storage_account_name, client_config.storage_access_key)
         super(signer, client_config.storage_account_name, options, &block)
         @host = client.storage_file_host
       end

--- a/lib/azure/storage/file/file_service.rb
+++ b/lib/azure/storage/file/file_service.rb
@@ -1,0 +1,191 @@
+#-------------------------------------------------------------------------
+# # Copyright (c) Microsoft and contributors. All rights reserved.
+#
+# The MIT License(MIT)
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#--------------------------------------------------------------------------
+require 'azure/storage/core/auth/shared_key'
+require 'azure/storage/file/serialization'
+require 'azure/storage/file/file'
+
+module Azure::Storage
+  module File
+    class FileService < StorageService
+      include Azure::Storage::Core::Utility
+      include Azure::Storage::File::Share
+      include Azure::Storage::File::Directory
+      include Azure::Storage::File
+
+      def initialize(options = {}, &block)
+        client_config = options[:client] || Azure::Storage
+        signer = options[:signer] || Core::Auth::SharedKey.new(client_config.storage_account_name, client_config.storage_access_key)
+        super(signer, client_config.storage_account_name, options, &block)
+        @host = client.storage_file_host
+      end
+
+      def call(method, uri, body=nil, headers={}, options={})
+        # Force the request.body to the content encoding of specified in the header
+        if headers && !body.nil? && (body.is_a? String) && ((body.encoding.to_s <=> 'ASCII_8BIT') != 0)
+          if headers['x-ms-content-type'].nil?
+            Service::StorageService.with_header headers, 'x-ms-content-type', "text/plain; charset=#{body.encoding}"
+          else
+            charset = parse_charset_from_content_type(headers['x-ms-content-type'])
+            body.force_encoding(charset) if charset
+          end
+        end
+
+        response = super
+
+        # Force the response.body to the content charset of specified in the header.
+        # Content-Type is echo'd back for the blob and is used to store the encoding of the octet stream
+        if !response.nil? && !response.body.nil? && response.headers['Content-Type']
+          charset = parse_charset_from_content_type(response.headers['Content-Type'])
+          response.body.force_encoding(charset) if charset && charset.length > 0
+        end
+
+        response
+      end
+
+      # Public: Get a list of Shares from the server.
+      #
+      # ==== Attributes
+      #
+      # * +options+                  - Hash. Optional parameters.
+      #
+      # ==== Options
+      #
+      # Accepted key/value pairs in options parameter are:
+      # * +:prefix+                  - String. Filters the results to return only shares
+      #                                whose name begins with the specified prefix. (optional)
+      #
+      # * +:marker+                  - String. An identifier the specifies the portion of the
+      #                                list to be returned. This value comes from the property
+      #                                Azure::Service::EnumerationResults.continuation_token when there
+      #                                are more shares available than were returned. The
+      #                                marker value may then be used here to request the next set
+      #                                of list items. (optional)
+      #
+      # * +:max_results+             - Integer. Specifies the maximum number of shares to return.
+      #                                If max_results is not specified, or is a value greater than
+      #                                5,000, the server will return up to 5,000 items. If it is set
+      #                                to a value less than or equal to zero, the server will return
+      #                                status code 400 (Bad Request). (optional)
+      #
+      # * +:metadata+                - Boolean. Specifies whether or not to return the share metadata.
+      #                                (optional, Default=false)
+      #
+      # * +:timeout+                 - Integer. A timeout in seconds.
+      #
+      # * +:request_id+              - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+      #                                in the analytics logs when storage analytics logging is enabled.
+      #
+      # See: https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/list-shares
+      #
+      # Returns an Azure::Service::EnumerationResults
+      #
+      def list_shares(options={})
+        query = { }
+        if options
+          StorageService.with_query query, 'prefix', options[:prefix]
+          StorageService.with_query query, 'marker', options[:marker]
+          StorageService.with_query query, 'maxresults', options[:max_results].to_s if options[:max_results]
+          StorageService.with_query query, 'include', 'metadata' if options[:metadata] == true
+          StorageService.with_query query, 'timeout', options[:timeout].to_s if options[:timeout]
+        end
+
+        uri = shares_uri(query)
+        response = call(:get, uri, nil, {}, options)
+
+        Serialization.share_enumeration_results_from_xml(response.body)
+      end
+
+      # Protected: Generate the URI for the collection of shares.
+      #
+      # ==== Attributes
+      #
+      # * +query+ - A Hash of key => value query parameters.
+      #
+      # Returns a URI.
+      #
+      protected
+      def shares_uri(query={})
+        query = { 'comp' => 'list' }.merge(query)
+        generate_uri('', query)
+      end
+
+      # Protected: Generate the URI for a specific share.
+      #
+      # ==== Attributes
+      #
+      # * +name+  - The share name. If this is a URI, we just return this.
+      # * +query+ - A Hash of key => value query parameters.
+      #
+      # Returns a URI.
+      #
+      protected
+      def share_uri(name, query={})
+        return name if name.kind_of? ::URI
+        query = { 'restype' => 'share' }.merge(query)
+        generate_uri(name, query)
+      end
+
+      # Protected: Generate the URI for a specific directory.
+      #
+      # ==== Attributes
+      #
+      # * +share+                 - String representing the name of the share.
+      # * +directory_path+        - String representing the path to the directory.
+      # * +directory+             - String representing the name to the directory.
+      # * +query+                 - A Hash of key => value query parameters.
+      #
+      # Returns a URI.
+      #
+      protected
+      def directory_uri(share, directory_path, query={})
+        path = directory_path.nil? ? share : ::File.join(share, directory_path)
+        query = { 'restype' => 'directory' }.merge(query)
+        generate_uri(path, query, true)
+      end
+
+      # Protected: Generate the URI for a specific file.
+      #
+      # ==== Attributes
+      #
+      # * +share+                 - String representing the name of the share.
+      # * +directory_path+        - String representing the path to the directory.
+      # * +file+                  - String representing the name to the file.
+      # * +query+                 - A Hash of key => value query parameters.
+      #
+      # Returns a URI.
+      #
+      protected
+      def file_uri(share, directory_path, file, query={})
+        if directory_path.nil?
+          path = ::File.join(share, file)
+        else
+          path = ::File.join(share, directory_path, file)
+        end
+        generate_uri(path, query, true)
+      end
+    end
+  end
+end
+
+Azure::Storage::FileService = Azure::Storage::File::FileService

--- a/lib/azure/storage/file/serialization.rb
+++ b/lib/azure/storage/file/serialization.rb
@@ -1,0 +1,225 @@
+#-------------------------------------------------------------------------
+# # Copyright (c) Microsoft and contributors. All rights reserved.
+#
+# The MIT License(MIT)
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#--------------------------------------------------------------------------
+require 'azure/storage/service/serialization'
+
+module Azure::Storage
+  module File
+    module Serialization
+      include Service::Serialization
+
+      def self.share_enumeration_results_from_xml(xml)
+        xml = slopify(xml)
+        expect_node("EnumerationResults", xml)
+
+        results = enumeration_results_from_xml(xml, Azure::Service::EnumerationResults.new)
+        
+        return results unless (xml > "Shares").any? && ((xml > "Shares") > "Share").any?
+
+        if xml.Shares.Share.count == 0
+          results.push(share_from_xml(xml.Shares.Share))
+        else
+          xml.Shares.Share.each { |share_node|
+            results.push(share_from_xml(share_node))
+          }
+        end
+
+        results
+      end
+
+      def self.share_from_xml(xml)
+        xml = slopify(xml)
+        expect_node("Share", xml)
+
+        Share::Share.new do |share|
+          share.name = xml.Name.text if (xml > "Name").any?
+          share.properties = share_properties_from_xml(xml.Properties) if (xml > "Properties").any?
+          share.metadata = metadata_from_xml(xml.Metadata) if (xml > "Metadata").any?
+        end
+      end
+
+      def self.share_properties_from_xml(xml)
+        xml = slopify(xml)
+        expect_node("Properties", xml)
+
+        props = {}
+        props[:last_modified] = (xml > "Last-Modified").text if (xml > "Last-Modified").any?
+        props[:etag] = xml.ETag.text if (xml > "ETag").any?
+        props[:quota] = xml.Quota.text if (xml > "Quota").any?
+        props
+      end
+
+      def self.share_from_headers(headers)
+        Share::Share.new do |share|
+          share.properties = share_properties_from_headers(headers)
+          share.quota = quota_from_headers(headers)
+          share.metadata = metadata_from_headers(headers)
+        end
+      end
+
+      def self.share_properties_from_headers(headers)
+        props = {}
+        props[:last_modified] = headers["Last-Modified"] 
+        props[:etag] = headers["ETag"]
+        props
+      end
+
+      def self.quota_from_headers(headers)
+        headers["x-ms-share-quota"] ? headers["x-ms-share-quota"].to_i : nil
+      end
+
+      def self.share_stats_from_xml(xml)
+        xml = slopify(xml)
+        expect_node("ShareStats", xml)
+        xml.ShareUsage.text.to_i
+      end
+
+      def self.directories_and_files_enumeration_results_from_xml(xml)
+        xml = slopify(xml)
+        expect_node("EnumerationResults", xml)
+
+        results = enumeration_results_from_xml(xml, Azure::Service::EnumerationResults.new)
+
+        return results unless (xml > "Entries").any?
+
+        if ((xml > "Entries") > "File").any?
+          if xml.Entries.File.count == 0
+            results.push(file_from_xml(xml.Entries.File))
+          else
+            xml.Entries.File.each { |file_node|
+              results.push(file_from_xml(file_node))
+            }
+          end
+        end
+
+        if ((xml > "Entries") > "Directory").any?
+          if xml.Entries.Directory.count == 0
+            results.push(directory_from_xml(xml.Entries.Directory))
+          else
+            xml.Entries.Directory.each { |directory_node|
+              results.push(directory_from_xml(directory_node))
+            }
+          end
+        end
+
+        results
+      end
+
+      def self.file_from_xml(xml)
+        xml = slopify(xml)
+        expect_node("File", xml)
+
+        File.new do |file|
+          file.name = xml.Name.text if (xml > "Name").any?
+          file.properties = file_properties_from_xml(xml.Properties) if (xml > "Properties").any?
+        end
+      end
+
+      def self.file_properties_from_xml(xml)
+        xml = slopify(xml)
+        expect_node("Properties", xml)
+
+        props = {}
+        props[:content_length] = (xml > "Content-Length").text.to_i if (xml > "Content-Length").any?
+        props
+      end
+
+      def self.directory_from_xml(xml)
+        xml = slopify(xml)
+        expect_node("Directory", xml)
+
+        Directory::Directory.new do |directory|
+          directory.name = xml.Name.text if (xml > "Name").any?
+        end
+      end
+
+      def self.directory_from_headers(headers)
+        Directory::Directory.new do |directory|
+          directory.properties = directory_properties_from_headers(headers)
+          directory.metadata = metadata_from_headers(headers)
+        end
+      end
+
+      def self.directory_properties_from_headers(headers)
+        props = {}
+        props[:last_modified] = headers["Last-Modified"] 
+        props[:etag] = headers["ETag"]
+        props
+      end
+
+      def self.file_from_headers(headers)
+        File.new do |file|
+          file.properties = file_properties_from_headers(headers)
+          file.metadata = metadata_from_headers(headers)
+        end
+      end
+
+      def self.file_properties_from_headers(headers)
+        props = {}
+
+        props[:last_modified] = headers["Last-Modified"]
+        props[:etag] = headers["ETag"]
+        props[:type] = headers["x-ms-type"]
+
+        props[:content_length] = headers["Content-Length"].to_i unless headers["Content-Length"].nil?
+        props[:content_length] = headers["x-ms-content-length"].to_i unless headers["x-ms-content-length"].nil?
+  
+        props[:content_type] =  headers["Content-Type"]
+        props[:content_encoding] = headers["Content-Encoding"]
+        props[:content_language] = headers["Content-Language"]
+        props[:content_disposition] = headers["Content-Disposition"]
+        props[:content_md5] = headers["Content-MD5"]
+        props[:cache_control] = headers["Cache-Control"]
+
+        props[:copy_id] = headers["x-ms-copy-id"]
+        props[:copy_status] = headers["x-ms-copy-status"]
+        props[:copy_source] = headers["x-ms-copy-source"]
+        props[:copy_progress] = headers["x-ms-copy-progress"]
+        props[:copy_completion_time] = headers["x-ms-copy-completion-time"]
+        props[:copy_status_description] = headers["x-ms-copy-status-description"]
+
+        props[:accept_ranges] = headers["Accept-Ranges"].to_i if headers["Accept-Ranges"]
+
+        props
+      end
+
+      def self.range_list_from_xml(xml)
+        xml = slopify(xml)
+        expect_node("Ranges", xml)
+
+        range_list = []
+        return range_list unless (xml > "Range").any?
+
+        if xml.Range.count == 0
+          range_list.push [xml.Range.Start.text.to_i, xml.Range.End.text.to_i]
+        else
+          xml.Range.each { |range|
+            range_list.push [range.Start.text.to_i, range.End.text.to_i]
+          }
+        end
+
+        range_list
+      end
+    end
+  end
+end

--- a/lib/azure/storage/file/share.rb
+++ b/lib/azure/storage/file/share.rb
@@ -1,0 +1,363 @@
+#-------------------------------------------------------------------------
+# # Copyright (c) Microsoft and contributors. All rights reserved.
+#
+# The MIT License(MIT)
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#--------------------------------------------------------------------------
+require 'azure/storage/file/serialization'
+
+module Azure::Storage::File
+  module Share
+    include Azure::Storage::Service
+    
+    class Share
+      def initialize
+        @properties = {}
+        @metadata = {}
+        yield self if block_given?
+      end
+
+      attr_accessor :name
+      attr_accessor :properties
+      attr_accessor :metadata
+      attr_accessor :quota
+      attr_accessor :usage
+    end
+
+    # Public: Create a new share
+    #
+    # ==== Attributes
+    #
+    # * +name+                      - String. The name of the share.
+    # * +options+                   - Hash. Optional parameters.
+    #
+    # ==== Options
+    #
+    # Accepted key/value pairs in options parameter are:
+    # * +:metadata+                 - Hash. User defined metadata for the share (optional).
+    # * +:quota+                    - Integer. The maximum size of the share, in gigabytes.
+    #                                 Must be greater than 0, and less than or equal to 5TB (5120). (optional).
+    # * +:timeout+                  - Integer. A timeout in seconds.
+    # * +:request_id+               - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+    #                                 in the analytics logs when storage analytics logging is enabled.
+    #
+    # See https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/create-share
+    #
+    # Returns a Share
+    def create_share(name, options={})
+      # Query
+      query = { }
+      query['timeout'] = options[:timeout].to_s if options[:timeout]
+
+      # Scheme + path
+      uri = share_uri(name, query)
+
+      # Headers
+      headers = StorageService.common_headers
+      StorageService.add_metadata_to_headers(options[:metadata], headers) if options[:metadata]
+      headers['x-ms-share-quota'] = options[:quota].to_s if options[:quota]
+
+      # Call
+      response = call(:put, uri, nil, headers, options)
+
+      # result
+      share = Serialization.share_from_headers(response.headers)
+      share.name = name
+      share.quota = options[:quota] if options[:quota]
+      share.metadata = options[:metadata] if options[:metadata]
+      share
+    end
+
+    # Public: Returns all properties and metadata on the share.
+    #
+    # ==== Attributes
+    #
+    # * +name+                      - String. The name of the share
+    # * +options+                   - Hash. Optional parameters.
+    #
+    # ==== Options
+    #
+    # Accepted key/value pairs in options parameter are:
+    # * +:timeout+                  - Integer. A timeout in seconds.
+    # * +:request_id+               - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+    #                                 in the analytics logs when storage analytics logging is enabled.
+    #
+    # See https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/get-share-properties
+    #
+    # Returns a Share
+    def get_share_properties(name, options={})
+      # Query
+      query = { }
+      query['timeout'] = options[:timeout].to_s if options[:timeout]
+
+      # Call
+      response = call(:get, share_uri(name, query), nil, {}, options)
+
+      # result
+      share = Serialization.share_from_headers(response.headers)
+      share.name = name
+      share
+    end
+
+    # Public: Sets service-defined properties for the share.
+    #
+    # ==== Attributes
+    #
+    # * +name+                      - String. The name of the share
+    # * +options+                   - Hash. Optional parameters.
+    #
+    # ==== Options
+    #
+    # Accepted key/value pairs in options parameter are:
+    # * +:quota+                    - Integer. The maximum size of the share, in gigabytes.
+    #                                 Must be greater than 0, and less than or equal to 5TB (5120). (optional).
+    # * +:timeout+                  - Integer. A timeout in seconds.
+    # * +:request_id+               - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+    #                                 in the analytics logs when storage analytics logging is enabled.
+    #
+    # See https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/set-share-properties
+    #
+    # Returns nil on success
+    def set_share_properties(name, options={})
+      # Query
+      query = { 'comp' => 'properties' }
+      query['timeout'] = options[:timeout].to_s if options[:timeout]
+
+      # Headers
+      headers = StorageService.common_headers
+      headers['x-ms-share-quota'] = options[:quota].to_s if options[:quota]
+
+      # Call
+      call(:put, share_uri(name, query), nil, headers, options)
+      
+      # Result
+      nil
+    end
+
+    # Public: Returns only user-defined metadata for the specified share.
+    #
+    # ==== Attributes
+    #
+    # * +name+                      - String. The name of the share
+    # * +options+                   - Hash. Optional parameters.
+    #
+    # ==== Options
+    #
+    # Accepted key/value pairs in options parameter are:
+    # * +:timeout+                  - Integer. A timeout in seconds.
+    # * +:request_id+               - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+    #                                 in the analytics logs when storage analytics logging is enabled.
+    #
+    # See https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/get-share-metadata
+    #
+    # Returns a Share
+    def get_share_metadata(name, options={})
+      # Query
+      query = { 'comp' => 'metadata' }
+      query['timeout'] = options[:timeout].to_s if options[:timeout]
+
+      # Call
+      response = call(:get, share_uri(name, query), nil, {}, options)
+
+      # result
+      share = Serialization.share_from_headers(response.headers)
+      share.name = name
+      share
+    end
+
+    # Public: Sets custom metadata for the share.
+    #
+    # ==== Attributes
+    #
+    # * +name+                      - String. The name of the share
+    # * +metadata+                  - Hash. A Hash of the metadata values
+    # * +options+                   - Hash. Optional parameters.
+    #
+    # ==== Options
+    #
+    # Accepted key/value pairs in options parameter are:
+    # * +:timeout+                  - Integer. A timeout in seconds.
+    # * +:request_id+               - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+    #                                 in the analytics logs when storage analytics logging is enabled.
+    #
+    # See https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/set-share-metadata
+    #
+    # Returns nil on success
+    def set_share_metadata(name, metadata, options={})
+      # Query
+      query = { 'comp' => 'metadata' }
+      query['timeout'] = options[:timeout].to_s if options[:timeout]
+
+      # Headers
+      headers = StorageService.common_headers
+      StorageService.add_metadata_to_headers(metadata, headers) if metadata
+
+      # Call
+      call(:put, share_uri(name, query), nil, headers, options)
+      
+      # Result
+      nil
+    end
+
+    # Public: Deletes a share.
+    #
+    # ==== Attributes
+    #
+    # * +name+                      - String. The name of the share.
+    # * +options+                   - Hash. Optional parameters.
+    #
+    # ==== Options
+    #
+    # Accepted key/value pairs in options parameter are:
+    # * +:timeout+                  - Integer. A timeout in seconds.
+    # * +:request_id+               - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+    #                                 in the analytics logs when storage analytics logging is enabled.
+    #
+    # See https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/delete-share
+    #
+    # Returns nil on success
+    def delete_share(name, options={})
+      # Query
+      query = { }
+      query['timeout'] = options[:timeout].to_s if options[:timeout]
+
+      # Call
+      call(:delete, share_uri(name, query), nil, {}, options)
+      
+      # result
+      nil
+    end
+
+    # Public: Gets the information about stored access policies for the share.
+    #
+    # ==== Attributes
+    #
+    # * +name+                      - String. The name of the share
+    # * +options+                   - Hash. Optional parameters.
+    #
+    # ==== Options
+    #
+    # Accepted key/value pairs in options parameter are:
+    # * +:timeout+                  - Integer. A timeout in seconds.
+    # * +:request_id+               - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+    #                                 in the analytics logs when storage analytics logging is enabled.
+    #
+    # See https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/get-share-acl
+    #
+    # Returns a tuple of (share, signed_identifiers)
+    #   share                       - A Azure::Storage::File::Share::Share instance
+    #   signed_identifiers          - A list of Azure::Storage::Service::SignedIdentifier instances
+    #
+    def get_share_acl(name, options={})
+      # Query
+      query = { 'comp' => 'acl' }
+      query['timeout'] = options[:timeout].to_s if options[:timeout]
+      
+      # Call
+      response = call(:get, share_uri(name, query), nil, {}, options)
+
+      # Result
+      share = Serialization.share_from_headers(response.headers)
+      share.name = name
+
+      signed_identifiers = nil
+      signed_identifiers = Serialization.signed_identifiers_from_xml(response.body) if response.body != nil && response.body.length > 0
+
+      return share, signed_identifiers
+    end
+
+    # Public: Sets stored access policies the share.
+    #
+    # ==== Attributes
+    #
+    # * +name+                         - String. The name of the share
+    # * +options+                      - Hash. Optional parameters.
+    #
+    # ==== Options
+    #
+    # Accepted key/value pairs in options parameter are:
+    # * +:signed_identifiers+          - Array. A list of Azure::Storage::Service::SignedIdentifier instances.
+    # * +:timeout+                     - Integer. A timeout in seconds.
+    # * +:request_id+                  - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+    #                                    in the analytics logs when storage analytics logging is enabled.
+    # 
+    # See https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/set-share-acl
+    #
+    # Returns a tuple of (share, signed_identifiers)
+    # * +share+                        - A Azure::Storage::File::Share::Share instance
+    # * +signed_identifiers+           - A list of Azure::Storage::Service::SignedIdentifier instances
+    #
+    def set_share_acl(name, options={})
+      # Query
+      query = { 'comp' => 'acl' }
+      query['timeout'] = options[:timeout].to_s if options[:timeout]
+
+      # Scheme + path
+      uri = share_uri(name, query)
+
+      # Headers + body
+      headers = StorageService.common_headers
+
+      signed_identifiers = options[:signed_identifiers] ? options[:signed_identifiers] : nil
+      body = signed_identifiers ? Serialization.signed_identifiers_to_xml(signed_identifiers) : nil
+
+      # Call
+      response = call(:put, uri, body, headers, options)
+
+      # Result
+      share = Serialization.share_from_headers(response.headers)
+      share.name = name
+
+      return share, signed_identifiers || []
+    end
+
+    # Public: Retrieves statistics related to the share.
+    #
+    # ==== Attributes
+    #
+    # * +name+                      - String. The name of the share
+    # * +options+                   - Hash. Optional parameters.
+    #
+    # ==== Options
+    #
+    # Accepted key/value pairs in options parameter are:
+    # * +:timeout+                  - Integer. A timeout in seconds.
+    # * +:request_id+               - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
+    #                                 in the analytics logs when storage analytics logging is enabled.
+    #
+    # See https://docs.microsoft.com/en-us/rest/api/storageservices/fileservices/get-share-stats
+    #
+    # Returns a Share
+    def get_share_stats(name, options={})
+      # Query
+      query = { 'comp' => 'stats' }
+      query['timeout'] = options[:timeout].to_s if options[:timeout]
+
+      # Call
+      response = call(:get, share_uri(name, query), nil, {}, options)
+
+      # result
+      share = Serialization.share_from_headers(response.headers)
+      share.name = name
+      share.usage = Serialization.share_stats_from_xml(response.body)
+      share
+    end
+  end
+end

--- a/lib/azure/storage/queue/queue_service.rb
+++ b/lib/azure/storage/queue/queue_service.rb
@@ -32,7 +32,7 @@ module Azure::Storage
 
       def initialize(options = {}, &block)
         client_config = options[:client] || Azure::Storage
-        signer = options[:signer] || Azure::Storage::Core::Auth::SharedKey.new(client_config.storage_account_name, client_config.storage_access_key)
+        signer = options[:signer] || client_config.signer || Azure::Storage::Core::Auth::SharedKey.new(client_config.storage_account_name, client_config.storage_access_key)
         super(signer, client_config.storage_account_name, options, &block)
         @host = @client.storage_queue_host
       end

--- a/lib/azure/storage/service/storage_service.rb
+++ b/lib/azure/storage/service/storage_service.rb
@@ -106,13 +106,24 @@ module Azure::Storage
       # query   - Hash. the query parameters
       #
       # Returns the uri hash
-      def generate_uri(path='', query={})
+      def generate_uri(path='', query={}, encode=false)
         if self.client.is_a?(Azure::Storage::Client) && self.client.options[:use_path_style_uri]
           if path.length > 0
             path = self.client.options[:storage_account_name] + '/' + path
           else
             path = self.client.options[:storage_account_name]
           end
+        end
+
+        if encode
+          path = CGI.escape(path.encode('UTF-8'))
+
+          # decode the forward slashes to match what the server expects.
+          path = path.gsub(/%2F/, '/')
+          # decode the backward slashes to match what the server expects.
+          path = path.gsub(/%5C/, '/')
+          # Re-encode the spaces (encoded as space) to the % encoding.
+          path = path.gsub(/\+/, '%20')
         end
 
         super path, query

--- a/lib/azure/storage/service/storage_service.rb
+++ b/lib/azure/storage/service/storage_service.rb
@@ -60,13 +60,16 @@ module Azure::Storage
       #
       # ==== Options
       #
+      # * +:timeout+                   - Integer. A timeout in seconds.
       # * +:request_id+                - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
       #                                  in the analytics logs when storage analytics logging is enabled.
       #
       # Returns a Hash with the service properties or nil if the operation failed
       def get_service_properties(options={})
-        uri = service_properties_uri
-        response = call(:get, uri, nil, {}, options)
+        query = { }
+        StorageService.with_query query, 'timeout', options[:timeout].to_s if options[:timeout]
+
+        response = call(:get, service_properties_uri(query), nil, {}, options)
         Serialization.service_properties_from_xml response.body
       end
 
@@ -79,14 +82,17 @@ module Azure::Storage
       #
       # ==== Options
       #
+      # * +:timeout+                   - Integer. A timeout in seconds.
       # * +:request_id+                - String. Provides a client-generated, opaque value with a 1 KB character limit that is recorded 
       #                                  in the analytics logs when storage analytics logging is enabled.
       #
       # Returns boolean indicating success.
       def set_service_properties(service_properties, options={})
+        query = { }
+        StorageService.with_query query, 'timeout', options[:timeout].to_s if options[:timeout]
+
         body = Serialization.service_properties_to_xml service_properties
-        uri = service_properties_uri
-        call(:put, uri, body, {}, options)
+        call(:put, service_properties_uri(query), body, {}, options)
         nil
       end
 

--- a/lib/azure/storage/table/table_service.rb
+++ b/lib/azure/storage/table/table_service.rb
@@ -576,7 +576,7 @@ module Azure::Storage
                  "%s()" % table_name.encode("UTF-8")
                end
 
-        uri = generate_uri(path)
+        uri = generate_uri(path, query, false)
         qs = []
         if query
           query.each do | key, val |

--- a/lib/azure/storage/table/table_service.rb
+++ b/lib/azure/storage/table/table_service.rb
@@ -33,7 +33,7 @@ module Azure::Storage
 
       def initialize(options = {}, &block)
         client_config = options[:client] || Azure::Storage
-        signer = options[:signer] || Auth::SharedKey.new(client_config.storage_account_name, client_config.storage_access_key)
+        signer = options[:signer] || client_config.signer || Auth::SharedKey.new(client_config.storage_account_name, client_config.storage_access_key)
         super(signer, client_config.storage_account_name, options, &block)
         @host = client.storage_table_host
       end

--- a/lib/azure/storage/table/table_service.rb
+++ b/lib/azure/storage/table/table_service.rb
@@ -236,7 +236,6 @@ module Azure::Storage
         query['timeout'] = options[:timeout].to_s if options[:timeout]
 
         response = call(:post, entities_uri(table_name, nil, nil, query), body, {}, options)
-        
         result = Table::Serialization.hash_from_entry_xml(response.body)
 
         Entity.new do |entity|
@@ -469,7 +468,6 @@ module Azure::Storage
 
         query = { }
         query["timeout"] = options[:timeout].to_s if options[:timeout]
-
         call(:delete, entities_uri(table_name, partition_key, row_key, query), nil, { "If-Match"=> if_match }, options)
         nil
       end
@@ -576,7 +574,7 @@ module Azure::Storage
                  "%s()" % table_name.encode("UTF-8")
                end
 
-        uri = generate_uri(path, query, false)
+        uri = generate_uri(path)
         qs = []
         if query
           query.each do | key, val |

--- a/lib/azure/storage/version.rb
+++ b/lib/azure/storage/version.rb
@@ -27,8 +27,8 @@ module Azure
     class Version
       # Fields represent the parts defined in http://semver.org/
       MAJOR = 0 unless defined? MAJOR
-      MINOR = 11 unless defined? MINOR
-      UPDATE = 5 unless defined? UPDATE
+      MINOR = 12 unless defined? MINOR
+      UPDATE = 0 unless defined? UPDATE
       PRE = 'preview' unless defined? PRE
 
       class << self

--- a/test/integration/auth/file_shared_access_signature_test.rb
+++ b/test/integration/auth/file_shared_access_signature_test.rb
@@ -1,0 +1,161 @@
+#-------------------------------------------------------------------------
+# # Copyright (c) Microsoft and contributors. All rights reserved.
+#
+# The MIT License(MIT)
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#--------------------------------------------------------------------------
+require 'integration/test_helper'
+require 'azure/storage/core/auth/shared_access_signature'
+
+describe Azure::Storage::Core::Auth::SharedAccessSignature do
+  subject { Azure::Storage::File::FileService.new }
+  let(:generator) { Azure::Storage::Core::Auth::SharedAccessSignature.new }
+
+  describe '#file_service_sas_for_share' do
+    let(:share_name) { ShareNameHelper.name }
+    let(:directory_name) { FileNameHelper.name }
+    let(:file_name) { FileNameHelper.name }
+    let(:file_length) { 1024 }
+    let(:content) { content = ""; file_length.times.each{ |i| content << "@" }; content }
+    before {
+      subject.create_share share_name
+      subject.create_directory share_name, directory_name
+      subject.create_file share_name, directory_name, file_name, file_length
+      subject.put_file_range share_name, directory_name, file_name, 0, file_length - 1, content
+    }
+    after { ShareNameHelper.clean }
+
+    it 'create a file with share permission' do
+      sas_token = generator.generate_service_sas_token "#{share_name}", {service: 'f', resource: 's', permissions: 'c', protocol: 'https'}
+      signer = Azure::Storage::Core::Auth::SharedAccessSignatureSigner.new Azure::Storage.storage_account_name, sas_token
+      client = Azure::Storage::File::FileService.new(signer: signer)
+
+      new_file_name = FileNameHelper.name
+      new_file = subject.create_file share_name, directory_name, new_file_name, file_length
+      new_file.wont_be_nil
+      new_file.name.must_equal new_file_name
+      new_file.properties[:last_modified].wont_be_nil
+      new_file.properties[:etag].wont_be_nil
+      new_file.properties[:content_length].wont_be_nil
+    end
+
+    it 'write a file with share permission' do
+      sas_token = generator.generate_service_sas_token "#{share_name}", {service: 'f', resource: 's', permissions: 'c', protocol: 'https'}
+      signer = Azure::Storage::Core::Auth::SharedAccessSignatureSigner.new Azure::Storage.storage_account_name, sas_token
+      client = Azure::Storage::File::FileService.new(signer: signer)
+
+      new_file_name = FileNameHelper.name
+      new_file = subject.create_file share_name, directory_name, new_file_name, file_length
+      new_file.wont_be_nil
+      
+      sas_token = generator.generate_service_sas_token "#{share_name}", {service: 'f', resource: 's', permissions: 'w', protocol: 'https'}
+      signer = Azure::Storage::Core::Auth::SharedAccessSignatureSigner.new Azure::Storage.storage_account_name, sas_token
+      client = Azure::Storage::File::FileService.new(signer: signer)
+
+      file = subject.put_file_range share_name, directory_name, new_file_name, 0, file_length - 1, content
+      file.wont_be_nil
+      file.name.must_equal new_file_name
+    end
+
+    it 'reads a file property with share permission' do
+      sas_token = generator.generate_service_sas_token "#{share_name}", {service: 'f', resource: 's', permissions: 'r', protocol: 'https'}
+      signer = Azure::Storage::Core::Auth::SharedAccessSignatureSigner.new Azure::Storage.storage_account_name, sas_token
+      client = Azure::Storage::File::FileService.new(signer: signer)
+
+      file_properties = client.get_file_properties share_name, directory_name, file_name
+      file_properties.wont_be_nil
+      file_properties.name.must_equal file_name
+      file_properties.properties[:last_modified].wont_be_nil
+      file_properties.properties[:etag].wont_be_nil
+      file_properties.properties[:content_length].must_equal file_length
+      file_properties.properties[:type].must_equal 'File'
+    end
+
+    it 'list a file with share permission' do
+      sas_token = generator.generate_service_sas_token "#{share_name}", {service: 'f', resource: 's', permissions: 'l', protocol: 'https'}
+      signer = Azure::Storage::Core::Auth::SharedAccessSignatureSigner.new Azure::Storage.storage_account_name, sas_token
+      client = Azure::Storage::File::FileService.new(signer: signer)
+      files = client.list_directories_and_files share_name, nil
+      files.wont_be_nil
+      assert files.length > 0
+    end
+
+    it 'deletes a file with share permission' do
+      sas_token = generator.generate_service_sas_token "#{share_name}", {service: 'f', resource: 's', permissions: 'd', protocol: 'https,http'}
+      signer = Azure::Storage::Core::Auth::SharedAccessSignatureSigner.new Azure::Storage.storage_account_name, sas_token
+      client = Azure::Storage::File::FileService.new(signer: signer)
+      result = client.delete_file share_name, directory_name, file_name
+      result.must_be_nil
+    end
+
+    it 'create a file with file permission' do
+      sas_token = generator.generate_service_sas_token "#{share_name}/#{directory_name}/#{file_name}", {service: 'f', resource: 'f', permissions: 'c', protocol: 'https'}
+      signer = Azure::Storage::Core::Auth::SharedAccessSignatureSigner.new Azure::Storage.storage_account_name, sas_token
+      client = Azure::Storage::File::FileService.new(signer: signer)
+
+      new_file_name = FileNameHelper.name
+      new_file = subject.create_file share_name, directory_name, new_file_name, file_length
+      new_file.wont_be_nil
+      new_file.name.must_equal new_file_name
+      new_file.properties[:last_modified].wont_be_nil
+      new_file.properties[:etag].wont_be_nil
+      new_file.properties[:content_length].wont_be_nil
+    end
+
+    it 'write a file with file permission' do
+      sas_token = generator.generate_service_sas_token "#{share_name}/#{directory_name}/#{file_name}", {service: 'f', resource: 'f', permissions: 'c', protocol: 'https'}
+      signer = Azure::Storage::Core::Auth::SharedAccessSignatureSigner.new Azure::Storage.storage_account_name, sas_token
+      client = Azure::Storage::File::FileService.new(signer: signer)
+
+      new_file_name = FileNameHelper.name
+      new_file = subject.create_file share_name, directory_name, new_file_name, file_length
+      new_file.wont_be_nil
+      
+      sas_token = generator.generate_service_sas_token "#{share_name}/#{directory_name}/#{file_name}", {service: 'f', resource: 'f', permissions: 'w', protocol: 'https'}
+      signer = Azure::Storage::Core::Auth::SharedAccessSignatureSigner.new Azure::Storage.storage_account_name, sas_token
+      client = Azure::Storage::File::FileService.new(signer: signer)
+
+      file = subject.put_file_range share_name, directory_name, new_file_name, 0, file_length - 1, content
+      file.wont_be_nil
+      file.name.must_equal new_file_name
+    end
+
+    it 'reads a file property with file permission' do
+      sas_token = generator.generate_service_sas_token "#{share_name}/#{directory_name}/#{file_name}", {service: 'f', resource: 'f', permissions: 'r', protocol: 'https'}
+      signer = Azure::Storage::Core::Auth::SharedAccessSignatureSigner.new Azure::Storage.storage_account_name, sas_token
+      client = Azure::Storage::File::FileService.new(signer: signer)
+      file_properties = client.get_file_properties share_name, directory_name, file_name
+      file_properties.wont_be_nil
+      file_properties.name.must_equal file_name
+      file_properties.properties[:last_modified].wont_be_nil
+      file_properties.properties[:etag].wont_be_nil
+      file_properties.properties[:content_length].must_equal file_length
+      file_properties.properties[:type].must_equal 'File'
+    end
+
+    it 'deletes a file with file permission' do
+      sas_token = generator.generate_service_sas_token "#{share_name}/#{directory_name}/#{file_name}", {service: 'f', resource: 'f', permissions: 'd', protocol: 'https'}
+      signer = Azure::Storage::Core::Auth::SharedAccessSignatureSigner.new Azure::Storage.storage_account_name, sas_token
+      client = Azure::Storage::File::FileService.new(signer: signer)
+      result = client.delete_file share_name, directory_name, file_name
+      result.must_be_nil
+    end
+  end
+end

--- a/test/integration/auth/queue_shared_access_signature_test.rb
+++ b/test/integration/auth/queue_shared_access_signature_test.rb
@@ -39,6 +39,16 @@ describe Azure::Storage::Core::Auth::SharedAccessSignature do
   }
   after { QueueNameHelper.clean }
 
+  it 'reads a message in the queue with a SAS in connection string' do
+    sas_token = generator.generate_service_sas_token queue_name, { service: 'q', permissions: 'r', protocol: 'https,http' }
+    connection_string = "QueueEndpoint=https://#{ENV['AZURE_STORAGE_ACCOUNT']}.queue.core.windows.net;SharedAccessSignature=#{sas_token}"
+    sas_client = Azure::Storage::Client::create_from_connection_string connection_string
+    client = sas_client.queue_client
+    message = client.peek_messages queue_name, { number_of_messages: 2 }
+    message.wont_be_nil
+    assert message.length > 1
+  end
+
   it 'reads a message in the queue with a SAS' do
     sas_token = generator.generate_service_sas_token queue_name, { service: 'q', permissions: 'r', protocol: 'https,http' }
     signer = Azure::Storage::Core::Auth::SharedAccessSignatureSigner.new Azure::Storage.storage_account_name, sas_token

--- a/test/integration/blob/append_blob_test.rb
+++ b/test/integration/blob/append_blob_test.rb
@@ -73,6 +73,7 @@ describe Azure::Storage::Blob::BlobService do
       blob.properties[:content_type].must_equal options[:content_type]
       blob.properties[:content_encoding].must_equal options[:content_encoding]
       blob.properties[:cache_control].must_equal options[:cache_control]
+      blob.metadata["custommetadataproperty"].must_equal "CustomMetadataValue"
 
       blob = subject.get_blob_metadata container_name, blob_name
       blob.name.must_equal blob_name

--- a/test/integration/blob/blob_gb18030_test.rb
+++ b/test/integration/blob/blob_gb18030_test.rb
@@ -149,7 +149,7 @@ describe 'Blob GB-18030' do
       end
     }
   end
-
+  
   it 'Read/Write Blob Block Content UTF-8 with auto charset' do
     GB18030TestStrings.get.each { |k,v|
       blob_name = 'Read/Write Block Blob Content UTF-8 for ' + k

--- a/test/integration/blob/block_blob_test.rb
+++ b/test/integration/blob/block_blob_test.rb
@@ -87,6 +87,7 @@ describe Azure::Storage::Blob::BlobService do
       blob.properties[:content_type].must_equal options[:content_type]
       blob.properties[:content_encoding].must_equal options[:content_encoding]
       blob.properties[:cache_control].must_equal options[:cache_control]
+      blob.metadata["custommetadataproperty"].must_equal "CustomMetadataValue"
 
       blob = subject.get_blob_metadata container_name, blob_name
       blob.name.must_equal blob_name

--- a/test/integration/blob/create_page_blob_test.rb
+++ b/test/integration/blob/create_page_blob_test.rb
@@ -77,6 +77,7 @@ describe Azure::Storage::Blob::BlobService do
       blob.properties[:content_type].must_equal options[:content_type]
       blob.properties[:content_encoding].must_equal options[:content_encoding]
       blob.properties[:cache_control].must_equal options[:cache_control]
+      blob.metadata["custommetadataproperty"].must_equal "CustomMetadataValue"
 
       blob = subject.get_blob_metadata container_name, blob_name
       blob.name.must_equal blob_name

--- a/test/integration/blob/list_blobs_test.rb
+++ b/test/integration/blob/list_blobs_test.rb
@@ -35,7 +35,7 @@ describe Azure::Storage::Blob::BlobService do
     let(:metadata) { { "CustomMetadataProperty"=>"CustomMetadataValue" } }
     let(:options) { { :content_type=>"application/foo", :metadata => metadata } }
 
-    before { 
+    before {
       subject.create_container container_name
       blob_names.each { |blob_name|
         subject.create_block_blob container_name, blob_name, content, options

--- a/test/integration/file/create_directory_test.rb
+++ b/test/integration/file/create_directory_test.rb
@@ -1,0 +1,73 @@
+#-------------------------------------------------------------------------
+# # Copyright (c) Microsoft and contributors. All rights reserved.
+#
+# The MIT License(MIT)
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#--------------------------------------------------------------------------
+require 'azure/core/http/http_error'
+require 'integration/test_helper'
+
+describe Azure::Storage::File::FileService do
+  subject { Azure::Storage::File::FileService.new }
+  after { ShareNameHelper.clean }
+
+  describe '#create_directory' do
+    let(:share_name) { ShareNameHelper.name }
+    let(:directory_name) { FileNameHelper.name }
+    before {
+      subject.create_share share_name
+    }
+
+    it 'creates the directory' do
+      directory = subject.create_directory share_name, directory_name
+      directory.name.must_equal directory_name
+    end
+
+    it 'creates the directory with custom metadata' do
+      metadata = { 'CustomMetadataProperty' => 'CustomMetadataValue'}
+
+      directory = subject.create_directory share_name, directory_name, { :metadata => metadata }
+      
+      directory.name.must_equal directory_name
+      directory.metadata.must_equal metadata
+      directory = subject.get_directory_metadata share_name, directory_name
+
+      metadata.each { |k,v|
+        directory.metadata.must_include k.downcase
+        directory.metadata[k.downcase].must_equal v
+      }
+    end
+
+    it 'errors if the directory already exists' do
+      subject.create_directory share_name, directory_name
+      
+      assert_raises(Azure::Core::Http::HTTPError) do
+        subject.create_directory share_name, directory_name
+      end
+    end
+    
+    it 'errors if the directory name is invalid' do
+      assert_raises(Azure::Core::Http::HTTPError) do
+        subject.create_directory share_name, 'this_directory/cannot/exist!'
+      end
+    end
+  end
+end
+

--- a/test/integration/file/create_file_test.rb
+++ b/test/integration/file/create_file_test.rb
@@ -1,0 +1,78 @@
+#-------------------------------------------------------------------------
+# # Copyright (c) Microsoft and contributors. All rights reserved.
+#
+# The MIT License(MIT)
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#--------------------------------------------------------------------------
+require 'azure/core/http/http_error'
+require 'integration/test_helper'
+
+describe Azure::Storage::File::FileService do
+  subject { Azure::Storage::File::FileService.new }
+  after { ShareNameHelper.clean }
+
+  describe '#create_file' do
+    let(:share_name) { ShareNameHelper.name }
+    let(:directory_name) { FileNameHelper.name }
+    let(:file_name) { FileNameHelper.name }
+    let(:file_length) { 1024 }
+    before {
+      subject.create_share share_name
+      subject.create_directory share_name, directory_name
+    }
+
+    it 'creates the file' do
+      file = subject.create_file share_name, directory_name, file_name, file_length
+      file.name.must_equal file_name
+
+      file = subject.get_file_properties share_name, directory_name, file_name
+      file.properties[:content_length].must_equal file_length
+    end
+
+    it 'creates the file with custom metadata' do
+      metadata = { 'CustomMetadataProperty' => 'CustomMetadataValue'}
+      file = subject.create_file share_name, directory_name, file_name, file_length, { :metadata => metadata }
+      
+      file.name.must_equal file_name
+      file.metadata.must_equal metadata
+      file = subject.get_file_metadata share_name, directory_name, file_name
+
+      metadata.each { |k,v|
+        file.metadata.must_include k.downcase
+        file.metadata[k.downcase].must_equal v
+      }
+    end
+
+    it 'no errors if the file already exists' do
+      subject.create_file share_name, directory_name, file_name, file_length
+      subject.create_file share_name, directory_name, file_name, file_length + file_length
+      file = subject.get_file_properties share_name, directory_name, file_name
+      file.name.must_equal file_name
+      file.properties[:content_length].must_equal file_length * 2
+    end
+    
+    it 'errors if the difilerectory name is invalid' do
+      assert_raises(Azure::Core::Http::HTTPError) do
+        subject.create_file share_name, directory_name, 'this_file/cannot/exist!', file_length
+      end
+    end
+  end
+end
+

--- a/test/integration/file/create_share_test.rb
+++ b/test/integration/file/create_share_test.rb
@@ -1,0 +1,68 @@
+#-------------------------------------------------------------------------
+# # Copyright (c) Microsoft and contributors. All rights reserved.
+#
+# The MIT License(MIT)
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#--------------------------------------------------------------------------
+require 'azure/core/http/http_error'
+require 'integration/test_helper'
+
+describe Azure::Storage::File::FileService do
+  subject { Azure::Storage::File::FileService.new }
+  after { ShareNameHelper.clean }
+
+  describe '#create_share' do
+    let(:share_name) { ShareNameHelper.name }
+
+    it 'creates the share' do
+      share = subject.create_share share_name
+      share.name.must_equal share_name
+    end
+
+    it 'creates the share with custom metadata' do
+      metadata = { 'CustomMetadataProperty' => 'CustomMetadataValue'}
+
+      share = subject.create_share share_name, { :metadata => metadata }
+      
+      share.name.must_equal share_name
+      share.metadata.must_equal metadata
+      share = subject.get_share_metadata share_name
+
+      metadata.each { |k,v|
+        share.metadata.must_include k.downcase
+        share.metadata[k.downcase].must_equal v
+      }
+    end
+
+    it 'errors if the share already exists' do
+      subject.create_share share_name
+      
+      assert_raises(Azure::Core::Http::HTTPError) do
+        subject.create_share share_name
+      end
+    end
+    
+    it 'errors if the share name is invalid' do
+      assert_raises(Azure::Core::Http::HTTPError) do
+        subject.create_share 'this_share.cannot-exist!'
+      end
+    end
+  end
+end

--- a/test/integration/file/delete_directory_test.rb
+++ b/test/integration/file/delete_directory_test.rb
@@ -1,0 +1,55 @@
+#-------------------------------------------------------------------------
+# # Copyright (c) Microsoft and contributors. All rights reserved.
+#
+# The MIT License(MIT)
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#--------------------------------------------------------------------------
+require 'integration/test_helper'
+
+describe Azure::Storage::File::FileService do
+  subject { Azure::Storage::File::FileService.new }
+  after { ShareNameHelper.clean }
+
+  describe '#delete_directory' do
+    let(:share_name) { ShareNameHelper.name }
+    let(:directory_name) { FileNameHelper.name }
+    before { 
+      subject.create_share share_name
+      subject.create_directory share_name, directory_name
+    }
+
+    it 'deletes the directory' do
+      directory = subject.get_directory_properties share_name, directory_name
+
+      result = subject.delete_directory share_name, directory_name
+      result.must_be_nil
+
+      assert_raises(Azure::Core::Http::HTTPError) do
+        subject.get_directory_properties share_name, directory_name
+      end
+    end
+
+    it 'errors if the directory does not exist' do
+      assert_raises(Azure::Core::Http::HTTPError) do
+        subject.delete_directory share_name, FileNameHelper.name
+      end
+    end
+  end
+end

--- a/test/integration/file/delete_file_test.rb
+++ b/test/integration/file/delete_file_test.rb
@@ -1,0 +1,59 @@
+#-------------------------------------------------------------------------
+# # Copyright (c) Microsoft and contributors. All rights reserved.
+#
+# The MIT License(MIT)
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#--------------------------------------------------------------------------
+require 'integration/test_helper'
+
+describe Azure::Storage::File::FileService do
+  subject { Azure::Storage::File::FileService.new }
+  after { ShareNameHelper.clean }
+
+  describe '#delete_file' do
+    let(:share_name) { ShareNameHelper.name }
+    let(:directory_name) { FileNameHelper.name }
+    let(:file_name) { FileNameHelper.name }
+    let(:file_length) { 1024 }
+    before { 
+      subject.create_share share_name
+      subject.create_directory share_name, directory_name
+      subject.create_file share_name, directory_name, file_name, file_length
+    }
+
+    it 'deletes the directory' do
+      file = subject.get_file_properties share_name, directory_name, file_name
+      file.properties[:content_length].must_equal file_length
+
+      result = subject.delete_file share_name, directory_name, file_name
+      result.must_be_nil
+
+      assert_raises(Azure::Core::Http::HTTPError) do
+        subject.get_file_properties share_name, directory_name, file_name
+      end
+    end
+
+    it 'errors if the directory does not exist' do
+      assert_raises(Azure::Core::Http::HTTPError) do
+        subject.delete_file share_name, directory_name, FileNameHelper.name
+      end
+    end
+  end
+end

--- a/test/integration/file/delete_share_test.rb
+++ b/test/integration/file/delete_share_test.rb
@@ -1,0 +1,54 @@
+#-------------------------------------------------------------------------
+# # Copyright (c) Microsoft and contributors. All rights reserved.
+#
+# The MIT License(MIT)
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#--------------------------------------------------------------------------
+require 'integration/test_helper'
+
+describe Azure::Storage::File::FileService do
+  subject { Azure::Storage::File::FileService.new }
+  after { ShareNameHelper.clean }
+
+  describe '#delete_share' do
+    let(:share_name) { ShareNameHelper.name }
+    before { 
+      subject.create_share share_name
+    }
+
+    it 'deletes the share' do
+      share = subject.get_share_stats share_name
+      share.usage.must_equal 0
+
+      result = subject.delete_share share_name
+      result.must_be_nil
+
+      assert_raises(Azure::Core::Http::HTTPError) do
+        subject.get_share_stats share_name
+      end
+    end
+
+    it 'errors if the share does not exist' do
+      assert_raises(Azure::Core::Http::HTTPError) do
+        subject.delete_share FileNameHelper.name
+      end
+    end
+  end
+end

--- a/test/integration/file/directory_metadata_test.rb
+++ b/test/integration/file/directory_metadata_test.rb
@@ -1,0 +1,65 @@
+#-------------------------------------------------------------------------
+# # Copyright (c) Microsoft and contributors. All rights reserved.
+#
+# The MIT License(MIT)
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#--------------------------------------------------------------------------
+require 'integration/test_helper'
+
+describe Azure::Storage::File::FileService do
+  let(:user_agent_prefix) { 'azure_storage_ruby_integration_test' }
+  subject { 
+    Azure::Storage::File::FileService.new { |headers|
+      headers['User-Agent'] = "#{user_agent_prefix}; #{headers['User-Agent']}"
+    }
+  }
+  after { ShareNameHelper.clean }
+  
+  describe '#set/get_directory_metadata' do
+    let(:share_name) { ShareNameHelper.name }
+    let(:directory_name) { FileNameHelper.name }
+    let(:metadata) { { "CustomMetadataProperty"=>"CustomMetadataValue" } }
+    before { 
+      subject.create_share share_name
+      subject.create_directory share_name, directory_name
+    }
+
+    it 'sets and gets custom metadata for the directory' do
+      result = subject.set_directory_metadata share_name, directory_name, metadata
+      result.must_be_nil
+      directory = subject.get_directory_metadata share_name, directory_name
+      directory.wont_be_nil
+      directory.name.must_equal directory_name
+      metadata.each { |k,v|
+        directory.metadata.must_include k.downcase
+        directory.metadata[k.downcase].must_equal v
+      }
+    end
+
+    it 'errors if the directory does not exist' do
+      assert_raises(Azure::Core::Http::HTTPError) do
+        subject.get_directory_metadata share_name, FileNameHelper.name
+      end
+      assert_raises(Azure::Core::Http::HTTPError) do
+        subject.set_directory_metadata share_name, FileNameHelper.name, metadata
+      end
+    end
+  end
+end

--- a/test/integration/file/directory_properties_test.rb
+++ b/test/integration/file/directory_properties_test.rb
@@ -1,0 +1,60 @@
+#-------------------------------------------------------------------------
+# # Copyright (c) Microsoft and contributors. All rights reserved.
+#
+# The MIT License(MIT)
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#--------------------------------------------------------------------------
+require 'integration/test_helper'
+
+describe Azure::Storage::File::FileService do
+  subject { Azure::Storage::File::FileService.new }
+  after { ShareNameHelper.clean }
+  
+  describe '#get_directory_properties' do
+    let(:share_name) { ShareNameHelper.name }
+    let(:directory_name) { FileNameHelper.name }
+    before {
+      subject.create_share share_name
+    }
+    let(:metadata) { { "CustomMetadataProperty"=>"CustomMetadataValue" } }
+
+    it 'gets properties and custom metadata for the directory' do
+      directory = subject.create_directory share_name, directory_name, { :metadata => metadata }
+      properties = directory.properties
+      
+      directory = subject.get_directory_properties share_name, directory_name
+      directory.wont_be_nil
+      directory.name.must_equal directory_name
+      directory.properties[:etag].must_equal properties[:etag]
+      directory.properties[:last_modified].must_equal properties[:last_modified]
+
+      metadata.each { |k,v|
+        directory.metadata.must_include k.downcase
+        directory.metadata[k.downcase].must_equal v
+      }
+    end
+
+    it 'errors if the directory does not exist' do
+      assert_raises(Azure::Core::Http::HTTPError) do
+        subject.get_directory_properties share_name, FileNameHelper.name
+      end
+    end
+  end
+end

--- a/test/integration/file/file_copy_test.rb
+++ b/test/integration/file/file_copy_test.rb
@@ -1,0 +1,131 @@
+#-------------------------------------------------------------------------
+# # Copyright (c) Microsoft and contributors. All rights reserved.
+#
+# The MIT License(MIT)
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#--------------------------------------------------------------------------
+require 'integration/test_helper'
+
+describe Azure::Storage::File::FileService do
+  subject { Azure::Storage::File::FileService.new }
+  after { ShareNameHelper.clean }
+  describe '#copy_file' do
+    let(:source_share_name) { ShareNameHelper.name }
+    let(:source_directory_name) { FileNameHelper.name }
+    let(:source_file_name) { "audio+video%25.mp4" }
+    let(:source_file_uri) { "https://#{Azure::Storage.storage_account_name}.file.core.windows.net/#{source_share_name}/#{source_directory_name}/#{CGI.escape(source_file_name).encode('UTF-8')}" }
+    let(:file_length) { 1024 }
+    let(:content) { content = ""; file_length.times.each{|i| content << "@" }; content }
+    let(:metadata){ {"custommetadata" => "CustomMetadataValue"} }
+
+    let(:dest_share_name) { ShareNameHelper.name }
+    let(:dest_directory_name) { FileNameHelper.name }
+    let(:dest_file_name) { "destaudio+video%25.mp4" }
+
+    before { 
+      subject.create_share source_share_name
+      subject.create_directory source_share_name, source_directory_name
+      subject.create_file source_share_name, source_directory_name, source_file_name, file_length
+      subject.put_file_range source_share_name, source_directory_name, source_file_name, 0, file_length - 1, content
+
+      subject.create_share dest_share_name
+      subject.create_directory dest_share_name, dest_directory_name
+    }
+
+    it 'copies an existing file to a new storage location' do
+      copy_id, copy_status = subject.copy_file dest_share_name, dest_directory_name, dest_file_name, source_share_name, source_directory_name, source_file_name
+      copy_id.wont_be_nil
+
+      file, returned_content = subject.get_file dest_share_name, dest_directory_name, dest_file_name
+
+      file.name.must_equal dest_file_name
+      returned_content.must_equal content
+    end
+
+    it 'copies an existing file from URI to a new storage location' do
+      copy_id, copy_status = subject.copy_file_from_uri dest_share_name, dest_directory_name, dest_file_name, source_file_uri
+      copy_id.wont_be_nil
+
+      file, returned_content = subject.get_file dest_share_name, dest_directory_name, dest_file_name
+
+      file.name.must_equal dest_file_name
+      returned_content.must_equal content
+    end
+
+    it 'returns a copyid which can be used to monitor status of the asynchronous copy operation' do
+      copy_id, copy_status = subject.copy_file dest_share_name, dest_directory_name, dest_file_name, source_share_name, source_directory_name, source_file_name
+      copy_id.wont_be_nil
+
+      counter = 0
+      finished = false
+      while(counter < 10 and not finished)
+        sleep(1)
+        file = subject.get_file_properties dest_share_name, dest_directory_name, dest_file_name
+        file.properties[:copy_id].must_equal copy_id
+        finished = file.properties[:copy_status] == "success"
+        counter +=1
+      end
+      finished.must_equal true
+
+      file, returned_content = subject.get_file dest_share_name, dest_directory_name, dest_file_name
+
+      file.name.must_equal dest_file_name
+      returned_content.must_equal content
+    end
+    
+    it 'returns a copyid which can be used to abort copy operation' do
+      copy_id, copy_status = subject.copy_file dest_share_name, dest_directory_name, dest_file_name, source_share_name, source_directory_name, source_file_name
+      copy_id.wont_be_nil
+
+      counter = 0
+      finished = false
+      while(counter < 10 and not finished)
+        sleep(1)
+        file = subject.get_file_properties dest_share_name, dest_directory_name, dest_file_name
+        file.properties[:copy_id].must_equal copy_id
+        finished = file.properties[:copy_status] == "success"
+        counter +=1
+      end
+      finished.must_equal true
+      
+      exception = assert_raises(Azure::Core::Http::HTTPError) do
+        subject.abort_copy_file dest_share_name, dest_directory_name, dest_file_name, copy_id
+      end
+      refute_nil(exception.message.index "NoPendingCopyOperation (409): There is currently no pending copy operation")
+    end
+
+    describe 'when a options hash is used' do
+      it 'replaces source metadata on the copy with provided Hash in :metadata property' do
+        copy_id, copy_status = subject.copy_file dest_share_name, dest_directory_name, dest_file_name, source_share_name, source_directory_name, source_file_name, { :metadata => metadata }
+        copy_id.wont_be_nil
+
+        file, returned_content = subject.get_file dest_share_name, dest_directory_name, dest_file_name
+        file.name.must_equal dest_file_name
+        returned_content.must_equal content
+
+        file = subject.get_file_metadata dest_share_name, dest_directory_name, dest_file_name
+        metadata.each { |k,v|
+          file.metadata.must_include k
+          file.metadata[k].must_equal v
+        }
+      end
+    end
+  end
+end

--- a/test/integration/file/file_gb18030_test.rb
+++ b/test/integration/file/file_gb18030_test.rb
@@ -1,0 +1,215 @@
+#-------------------------------------------------------------------------
+# # Copyright (c) Microsoft and contributors. All rights reserved.
+#
+# The MIT License(MIT)
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#--------------------------------------------------------------------------
+require 'integration/test_helper'
+
+describe 'File GB-18030' do
+  subject { Azure::Storage::File::FileService.new }
+  after { ShareNameHelper.clean }
+
+  let(:share_name) { ShareNameHelper.name }
+  let(:directory_name) { FileNameHelper.name }
+  let(:file_name) { 'rubyfilename' }
+  let(:file_length) { 64 }
+
+  before {
+    subject.create_share share_name
+    subject.create_directory share_name, directory_name
+    subject.create_file share_name, directory_name, file_name, file_length
+  }
+
+  it 'Read/Write File Share Name UTF-8' do
+    # Expected results: Failure, because the File
+    # share name can only contain ASCII
+    # characters, per the File Service spec.
+    GB18030TestStrings.get.each { |k,v|
+      begin
+        subject.create_share share_name + v.encode('UTF-8')
+        flunk 'No exception'
+      rescue
+        # Add validation?
+      end
+    }
+  end
+
+  it 'Read/Write File Share Name GB-18030' do
+    # Expected results: Failure, because the File
+    # share name can only contain ASCII
+    # characters, per the File Service spec.
+    GB18030TestStrings.get.each { |k,v|
+      begin
+        subject.create_share share_name + v.encode('GB18030')
+        flunk 'No exception'
+      rescue
+        # Add validation?
+      end
+    }
+  end
+
+  it 'Read/Write File Name UTF-8' do
+    share_name = ShareNameHelper.name
+    subject.create_share share_name
+    subject.create_directory share_name, directory_name
+
+    GB18030TestStrings.get.each { |k,v|
+      # The File service does not support characters from extended plains.
+      if k != 'ChineseExtB' and k != 'Chinese2B5' then
+        test_name = share_name + v.encode('UTF-8')
+        subject.create_file share_name, directory_name, test_name, file_length
+        files = subject.list_directories_and_files share_name, directory_name
+        files.each { |value|
+          value.name.must_equal test_name
+        }
+        subject.delete_file share_name, directory_name, test_name
+      end
+    }
+  end
+
+  # Fails because of https://github.com/appfog/azure-sdk-for-ruby/issues/293
+  it 'Read/Write File Name GB18030' do
+    share_name = ShareNameHelper.name
+    subject.create_share share_name
+    subject.create_directory share_name, directory_name
+    GB18030TestStrings.get.each { |k,v|
+      # The File service does not support characters from extended plains.
+      if k != 'ChineseExtB' and k != 'Chinese2B5' then
+        test_name = share_name + v.encode('GB18030')
+        subject.create_file share_name, directory_name, test_name, file_length
+        files = subject.list_directories_and_files share_name, directory_name
+        files.each { |value|
+          value.name.encode('UTF-8').must_equal test_name.encode('UTF-8')
+        }
+        subject.delete_file share_name, directory_name, test_name
+      end
+    }
+  end
+
+  it 'Read/Write File Metadata UTF-8 key' do
+    GB18030TestStrings.get.each { |k,v|
+      begin
+        metadata = {'custommetadata' + v.encode('UTF-8') => 'CustomMetadataValue'}
+        subject.set_file_metadata share_name, directory_name, file_name, metadata
+        flunk 'No exception'
+      rescue Azure::Core::Http::HTTPError => error
+        error.status_code.must_equal 400
+      end
+    }
+  end
+
+  it 'Read/Write File Metadata GB-18030 key' do
+    GB18030TestStrings.get.each { |k,v|
+      begin
+        metadata = {'custommetadata' + v.encode('GB18030') => 'CustomMetadataValue'}
+        subject.set_file_metadata share_name, directory_name, file_name, metadata
+        flunk 'No exception'
+      rescue Azure::Core::Http::HTTPError => error
+        error.status_code.must_equal 400
+      end
+    }
+  end
+
+  it 'Read/Write File Metadata UTF-8 value' do
+    GB18030TestStrings.get.each { |k,v|
+      begin
+        metadata = {'custommetadata' => 'CustomMetadataValue' + v.encode('UTF-8')}
+        subject.set_file_metadata share_name, directory_name, file_name, metadata
+        flunk 'No exception'
+      rescue Azure::Core::Http::HTTPError => error
+        # TODO: Error should really be 400
+        error.status_code.must_equal 403
+      end
+    }
+  end
+
+  it 'Read/Write File Metadata GB-18030 value' do
+    GB18030TestStrings.get.each { |k,v|
+      begin
+        metadata = {'custommetadata' => 'CustomMetadataValue' + v.encode('GB18030')}
+        subject.set_file_metadata share_name, directory_name, file_name, metadata
+        flunk 'No exception'
+      rescue Azure::Core::Http::HTTPError => error
+        # TODO: Error should really be 400
+        error.status_code.must_equal 403
+      end
+    }
+  end
+
+  it 'Read/Write File Content UTF-8 with auto charset' do
+    GB18030TestStrings.get.each { |k,v|
+      file_name = 'Read-Write File Content UTF-8 for ' + k
+      content = v.encode('UTF-8')
+      subject.create_file share_name, directory_name, file_name, content.bytesize
+      subject.put_file_range share_name, directory_name, file_name, 0, content.bytesize - 1, content
+      file, returned_content = subject.get_file share_name, directory_name, file_name
+      returned_content.must_equal content
+    }
+  end
+
+  it 'Read/Write File Content GB18030 with explicit charset' do
+    GB18030TestStrings.get.each { |k,v|
+      file_name = 'Read-Write File Content GB18030 for ' + k
+      content = v.encode('GB18030')
+      options = { :content_type => 'text/html; charset=GB18030' }
+      subject.create_file share_name, directory_name, file_name, content.bytesize, options
+      subject.put_file_range share_name, directory_name, file_name, 0, content.bytesize - 1, content
+      file, returned_content = subject.get_file share_name, directory_name, file_name
+      charset = file.properties[:content_type][file.properties[:content_type].index('charset=') + 'charset='.length...file.properties[:content_type].length]
+      returned_content.force_encoding(charset)
+      returned_content.must_equal content
+    }
+  end
+
+  it 'Read/Write 512 bytes UTF-8 with explicit charset' do
+    GB18030TestStrings.get.each { |k,v|
+      file_name = 'Read-Write File Content UTF-8 for ' + k
+      options = { :content_type => 'text/html; charset=UTF-8' }
+      content = v.encode('UTF-8')
+      while content.bytesize < 512 do
+        content << 'X'
+      end
+      subject.create_file share_name, directory_name, file_name, 512, options
+      subject.put_file_range share_name, directory_name, file_name, 0, 511, content
+      file, returned_content = subject.get_file share_name, directory_name, file_name
+      charset = file.properties[:content_type][file.properties[:content_type].index('charset=') + 'charset='.length...file.properties[:content_type].length]
+      returned_content.force_encoding(charset)
+      returned_content.must_equal content
+    }
+  end
+
+  it 'Read/Write 512 bytes GB18030 with explicit charset' do
+    GB18030TestStrings.get.each { |k,v|
+      file_name = 'Read-Write File Content GB18030 for ' + k
+      options = { :content_type => 'text/html; charset=GB18030' }
+      content = v.encode('GB18030')
+      while content.bytesize < 512 do
+        content << 'X'
+      end
+      subject.create_file share_name, directory_name, file_name, 512, options
+      subject.put_file_range share_name, directory_name, file_name, 0, 511, content
+      file, returned_content = subject.get_file share_name, directory_name, file_name
+      charset = file.properties[:content_type][file.properties[:content_type].index('charset=') + 'charset='.length...file.properties[:content_type].length]
+      returned_content.force_encoding(charset)
+      returned_content.must_equal content
+    }
+  end
+end

--- a/test/integration/file/file_metadata_test.rb
+++ b/test/integration/file/file_metadata_test.rb
@@ -1,0 +1,68 @@
+#-------------------------------------------------------------------------
+# # Copyright (c) Microsoft and contributors. All rights reserved.
+#
+# The MIT License(MIT)
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#--------------------------------------------------------------------------
+require 'integration/test_helper'
+
+describe Azure::Storage::File::FileService do
+  let(:user_agent_prefix) { 'azure_storage_ruby_integration_test' }
+  subject { 
+    Azure::Storage::File::FileService.new { |headers|
+      headers['User-Agent'] = "#{user_agent_prefix}; #{headers['User-Agent']}"
+    }
+  }
+  after { ShareNameHelper.clean }
+  
+  describe '#set/get_file_metadata' do
+    let(:share_name) { ShareNameHelper.name }
+    let(:directory_name) { FileNameHelper.name }
+    let(:file_name) { FileNameHelper.name }
+    let(:file_length) { 1024 }
+    let(:metadata) { { "CustomMetadataProperty"=>"CustomMetadataValue" } }
+    before { 
+      subject.create_share share_name
+      subject.create_directory share_name, directory_name
+      subject.create_file share_name, directory_name, file_name, file_length
+    }
+
+    it 'sets and gets custom file for the directory' do
+      result = subject.set_file_metadata share_name, directory_name, file_name, metadata
+      result.must_be_nil
+      file = subject.get_file_metadata share_name, directory_name, file_name
+      file.wont_be_nil
+      file.name.must_equal file_name
+      metadata.each { |k,v|
+        file.metadata.must_include k.downcase
+        file.metadata[k.downcase].must_equal v
+      }
+    end
+
+    it 'errors if the file does not exist' do
+      assert_raises(Azure::Core::Http::HTTPError) do
+        subject.get_file_metadata share_name, directory_name, FileNameHelper.name
+      end
+      assert_raises(Azure::Core::Http::HTTPError) do
+        subject.set_file_metadata share_name, directory_name, FileNameHelper.name, metadata
+      end
+    end
+  end
+end

--- a/test/integration/file/file_properties_test.rb
+++ b/test/integration/file/file_properties_test.rb
@@ -1,0 +1,91 @@
+#-------------------------------------------------------------------------
+# # Copyright (c) Microsoft and contributors. All rights reserved.
+#
+# The MIT License(MIT)
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#--------------------------------------------------------------------------
+require 'integration/test_helper'
+
+describe Azure::Storage::File::FileService do
+  subject { Azure::Storage::File::FileService.new }
+  after { ShareNameHelper.clean }
+
+  describe '#set/get_file_properties' do
+    let(:share_name) { ShareNameHelper.name }
+    let(:directory_name) { FileNameHelper.name }
+    let(:file_name) { FileNameHelper.name }
+    let(:file_length) { 1024 }
+    before {
+      subject.create_share share_name
+      subject.create_directory share_name, directory_name
+      subject.create_file share_name, directory_name, file_name, file_length
+    }
+    let(:options){{
+      :content_type=>"application/my-special-format",
+      :content_encoding=>"gzip",
+      :content_language=>"klingon",
+      :content_md5=>"5e1f7f9c28345d2b",
+      :content_disposition=>"attachment",
+      :cache_control=>"max-age=1296000",
+    }}
+
+    it 'sets and gets properties for a file' do
+      result = subject.set_file_properties share_name, directory_name, file_name, options
+      result.must_be_nil
+      file = subject.get_file_properties share_name, directory_name, file_name
+      file.properties[:content_type].must_equal options[:content_type]
+      file.properties[:content_encoding].must_equal options[:content_encoding]
+      file.properties[:cache_control].must_equal options[:cache_control]
+      file.properties[:content_md5].must_equal options[:content_md5]
+      file.properties[:content_disposition].must_equal options[:content_disposition]
+    end
+
+    it 'resize a file' do
+      result = subject.resize_file share_name, directory_name, file_name, file_length + file_length
+      result.must_be_nil
+      file = subject.get_file_properties share_name, directory_name, file_name
+      file.properties[:content_length].must_equal file_length * 2
+    end
+
+    it 'resize a file should not change other properties' do
+      result = subject.set_file_properties share_name, directory_name, file_name, options
+      result.must_be_nil
+
+      result = subject.resize_file share_name, directory_name, file_name, file_length + file_length
+      result.must_be_nil
+      file = subject.get_file_properties share_name, directory_name, file_name
+      file.properties[:content_length].must_equal file_length * 2
+      file.properties[:content_type].must_equal options[:content_type]
+      file.properties[:content_encoding].must_equal options[:content_encoding]
+      file.properties[:cache_control].must_equal options[:cache_control]
+      file.properties[:content_md5].must_equal options[:content_md5]
+      file.properties[:content_disposition].must_equal options[:content_disposition]
+    end
+
+    it 'errors if the file name does not exist' do
+      assert_raises(Azure::Core::Http::HTTPError) do
+        subject.get_file_properties share_name, directory_name, "thisfiledoesnotexist"
+      end
+      assert_raises(Azure::Core::Http::HTTPError) do
+        subject.get_file_properties share_name, directory_name, "thisfiledoesnotexist", options
+      end
+    end
+  end
+end

--- a/test/integration/file/file_range_test.rb
+++ b/test/integration/file/file_range_test.rb
@@ -1,0 +1,136 @@
+#-------------------------------------------------------------------------
+# # Copyright (c) Microsoft and contributors. All rights reserved.
+#
+# The MIT License(MIT)
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#--------------------------------------------------------------------------
+require 'integration/test_helper'
+
+describe Azure::Storage::File::FileService do
+  subject { Azure::Storage::File::FileService.new }
+  after { ShareNameHelper.clean }
+  
+  let(:share_name) { ShareNameHelper.name }
+  let(:directory_name) { FileNameHelper.name }
+  let(:file_name) { 'filename' }
+  let(:file_name2) { 'filename2' }
+  let(:file_length) { 2560 }
+  before { 
+    subject.create_share share_name
+    subject.create_directory share_name, directory_name
+    subject.create_file share_name, directory_name, file_name, file_length
+    subject.create_file share_name, directory_name, file_name2, file_length
+  }
+  
+  describe '#put_file_range' do
+    it 'creates ranges in a file' do
+      content = ''
+      512.times.each{|i| content << '@' }
+
+      subject.put_file_range share_name, directory_name, file_name, 0, 511, content
+      subject.put_file_range share_name, directory_name, file_name, 1024, 1535, content
+
+      file, ranges = subject.list_file_ranges share_name, directory_name, file_name, { :start_range => 0, :end_range => 1536 }
+      file.properties[:etag].wont_be_nil
+      file.properties[:last_modified].wont_be_nil
+      file.properties[:content_length].must_equal file_length
+      ranges[0][0].must_equal 0
+      ranges[0][1].must_equal 511
+      ranges[1][0].must_equal 1024
+      ranges[1][1].must_equal 1535
+    end
+  end
+
+  describe 'when the options hash is used' do
+    it 'if transactional_md5 match is specified' do
+      content = ''
+      512.times.each{|i| content << '@' }
+
+      file = subject.put_file_range share_name, directory_name, file_name, 0, 511, content
+      subject.put_file_range share_name, directory_name, file_name, 1024, 1535, content, { :transactional_md5 => Base64.strict_encode64(Digest::MD5.digest(content)) }
+    end
+    
+    it 'if transactional_md5 does not match' do
+      content = ''
+      512.times.each{|i| content << '@' }
+
+      assert_raises(Azure::Core::Http::HTTPError) do
+        file = subject.put_file_range share_name, directory_name, file_name2, 0, 511, content, {:transactional_md5 => '2105b16a6714bd9d'}
+      end
+    end
+  end
+
+  describe '#clear_file_ranges' do
+    before { 
+      content = ''
+      512.times.each{|i| content << '@' }
+
+      subject.put_file_range share_name, directory_name, file_name, 0, 511, content
+      subject.put_file_range share_name, directory_name, file_name, 1024, 1535, content
+      subject.put_file_range share_name, directory_name, file_name, 2048, 2559, content
+
+      file, ranges = subject.list_file_ranges share_name, directory_name, file_name, { :start_range => 0, :end_range => 2560 }
+      ranges.length.must_equal 3
+      ranges[0][0].must_equal 0
+      ranges[0][1].must_equal 511
+      ranges[1][0].must_equal 1024
+      ranges[1][1].must_equal 1535
+      ranges[2][0].must_equal 2048
+      ranges[2][1].must_equal 2559
+    }
+
+    describe 'when both start_range and end_range are specified' do
+      it 'clears the data in files within the provided range' do
+        subject.clear_file_range share_name, directory_name, file_name, 512, 1535
+
+        file, ranges = subject.list_file_ranges share_name, directory_name, file_name, { :start_range => 0, :end_range => 2560 }
+        file.properties[:etag].wont_be_nil
+        file.properties[:last_modified].wont_be_nil
+        file.properties[:content_length].must_equal file_length
+        ranges.length.must_equal 2
+        ranges[0][0].must_equal 0
+        ranges[0][1].must_equal 511
+        ranges[1][0].must_equal 2048
+        ranges[1][1].must_equal 2559
+      end
+    end
+  end
+
+  describe '#list_file_ranges' do
+    before { 
+      content = ''
+      512.times.each{|i| content << '@' }
+
+      subject.put_file_range share_name, directory_name, file_name, 0, 511, content
+      subject.put_file_range share_name, directory_name, file_name, 1024, 1535, content
+    }
+
+    it 'lists the active file ranges' do
+      file, ranges = subject.list_file_ranges share_name, directory_name, file_name, { :start_range => 0, :end_range => 1536 }
+      file.properties[:etag].wont_be_nil
+      file.properties[:last_modified].wont_be_nil
+      file.properties[:content_length].must_equal file_length
+      ranges[0][0].must_equal 0
+      ranges[0][1].must_equal 511
+      ranges[1][0].must_equal 1024
+      ranges[1][1].must_equal 1535
+    end
+  end
+end

--- a/test/integration/file/get_file_test.rb
+++ b/test/integration/file/get_file_test.rb
@@ -1,0 +1,60 @@
+#-------------------------------------------------------------------------
+# # Copyright (c) Microsoft and contributors. All rights reserved.
+#
+# The MIT License(MIT)
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#--------------------------------------------------------------------------
+require 'integration/test_helper'
+
+describe Azure::Storage::File::FileService do
+  subject { Azure::Storage::File::FileService.new }
+  after { ShareNameHelper.clean }
+
+  describe '#get_file' do
+    let(:share_name) { ShareNameHelper.name }
+    let(:directory_name) { FileNameHelper.name }
+    let(:file_name) { "filename" }
+    let(:file_length) { 1024 }
+    let(:content) { content = ""; file_length.times.each{|i| content << "@" }; content }
+    let(:metadata) { { "CustomMetadataProperty"=>"CustomMetadataValue" } }
+    let(:options) { { :content_type=>"application/foo", :metadata => metadata } }
+
+    before { 
+      subject.create_share share_name
+      subject.create_directory share_name, directory_name
+      subject.create_file share_name, directory_name, file_name, file_length, options
+      subject.put_file_range share_name, directory_name, file_name, 0, file_length - 1, content
+    }
+
+    it 'retrieves the file properties, metadata, and contents' do
+      file, returned_content = subject.get_file share_name, directory_name, file_name
+      returned_content.must_equal content
+      file.metadata.must_include "custommetadataproperty"
+      file.metadata["custommetadataproperty"].must_equal "CustomMetadataValue"
+      file.properties[:content_type].must_equal "application/foo"
+    end
+
+    it 'retrieves a range of data from the file' do
+      file, returned_content = subject.get_file share_name, directory_name, file_name, { :start_range => 0, :end_range => 511 }
+      returned_content.length.must_equal 512
+      returned_content.must_equal content[0..511]
+    end
+  end
+end

--- a/test/integration/file/list_directories_and_files_test.rb
+++ b/test/integration/file/list_directories_and_files_test.rb
@@ -1,0 +1,120 @@
+#-------------------------------------------------------------------------
+# # Copyright (c) Microsoft and contributors. All rights reserved.
+#
+# The MIT License(MIT)
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#--------------------------------------------------------------------------
+require 'integration/test_helper'
+
+describe Azure::Storage::File::FileService do
+  subject { Azure::Storage::File::FileService.new }
+  after { ShareNameHelper.clean }
+  
+  describe '#list_directories' do
+    let(:share_name) { ShareNameHelper.name }
+    let(:directories_names) { [FileNameHelper.name, FileNameHelper.name, FileNameHelper.name] }
+    let(:sub_directories_names) { [FileNameHelper.name, FileNameHelper.name, FileNameHelper.name] }
+    let(:metadata) { { "CustomMetadataProperty"=>"CustomMetadataValue" } }
+    before {
+      subject.create_share share_name, { :metadata => metadata }
+      directories_names.each { |directory_name|
+        subject.create_directory share_name, directory_name, { :metadata => metadata }
+        
+        sub_directories_names.each { |sub_directory_name|
+          sub_directory_path = ::File.join(directory_name, sub_directory_name)
+          subject.create_directory share_name, sub_directory_path, { :metadata => metadata }
+        }
+      }
+    }
+
+    it 'lists the level_1 directories for the account' do
+      result =  subject.list_directories_and_files share_name, nil
+      found = 0
+      result.each { |directory|
+        found += 1 if directories_names.include? directory.name
+      }
+      found.must_equal directories_names.length
+    end
+
+    it 'lists the level_2 directories for the account' do
+      result =  subject.list_directories_and_files share_name, nil
+      found = 0
+      result.each { |directory|
+        found += 1 if directories_names.include? directory.name
+
+        sub_result =  subject.list_directories_and_files share_name, directory.name
+        sub_result.each { |sub_directory_path|
+          found += 1
+        }
+      }
+      found.must_equal directories_names.length + directories_names.length * sub_directories_names.length
+    end
+
+    it 'lists the shares for the account with max results' do
+      result =  subject.list_directories_and_files(share_name, nil, { :max_results => 1 })
+      result.length.must_equal 1
+      first_directory = result[0]
+      result.continuation_token.wont_equal ""
+
+      result = subject.list_directories_and_files(share_name, nil, { :max_results => 2, :marker => result.continuation_token })
+      result.length.must_equal 2
+      result[0].name.wont_equal first_directory.name
+    end
+  end
+
+  describe '#list_directories_and_files' do
+    let(:share_name) { FileNameHelper.name }
+    let(:directories_names) { [FileNameHelper.name, FileNameHelper.name, FileNameHelper.name] }
+    let(:sub_directories_names) { [FileNameHelper.name, FileNameHelper.name, FileNameHelper.name] }
+    let(:file_names) { [FileNameHelper.name, FileNameHelper.name, FileNameHelper.name] }
+    let(:file_length) { 1024 }
+    let(:metadata) { { "CustomMetadataProperty"=>"CustomMetadataValue" } }
+    before {
+      subject.create_share share_name, { :metadata => metadata }
+      directories_names.each { |directory_name|
+        # Create level 1 directories
+        subject.create_directory share_name, directory_name, { :metadata => metadata }
+
+        # Create level 1 files
+        file_names.each { |file_name|
+          subject.create_file share_name, directory_name, file_name, file_length, { :metadata => metadata }
+        }
+
+        # Create level 2 directories
+        sub_directories_names.each { |sub_directory_name|
+          sub_directory_path = ::File.join(directory_name, sub_directory_name)
+          subject.create_directory share_name, sub_directory_path, { :metadata => metadata }
+        }
+      }
+    }
+
+    it 'lists the level_2 directories and files for the account' do
+      result =  subject.list_directories_and_files share_name, directories_names[0]
+      directory_found = 0
+      file_found = 0
+      result.each { |entry|
+        directory_found += 1 if sub_directories_names.include? entry.name and entry.is_a? Azure::Storage::File::Directory::Directory
+        file_found += 1 if file_names.include? entry.name and entry.is_a? Azure::Storage::File::File
+      }
+      directory_found.must_equal sub_directories_names.length
+      file_found.must_equal file_names.length
+    end
+  end
+end

--- a/test/integration/file/list_share_test.rb
+++ b/test/integration/file/list_share_test.rb
@@ -1,0 +1,75 @@
+#-------------------------------------------------------------------------
+# # Copyright (c) Microsoft and contributors. All rights reserved.
+#
+# The MIT License(MIT)
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#--------------------------------------------------------------------------
+require 'integration/test_helper'
+
+describe Azure::Storage::File::FileService do
+  subject { Azure::Storage::File::FileService.new }
+  after { ShareNameHelper.clean }
+  
+  describe '#list_shares' do
+    let(:share_names) { [ShareNameHelper.name, ShareNameHelper.name, ShareNameHelper.name] }
+    let(:metadata) { { "CustomMetadataProperty"=>"CustomMetadataValue" } }
+    before { 
+      share_names.each { |c|
+        subject.create_share c, { :metadata => metadata }
+      }
+    }
+
+    it 'lists the shares for the account' do
+      result =  subject.list_shares
+      found = 0
+      result.each { |c|
+        found += 1 if share_names.include? c.name
+      }
+      found.must_equal share_names.length
+    end
+
+    it 'lists the shares for the account with max results' do
+      result =  subject.list_shares({ :max_results => 1 })
+      result.length.must_equal 1
+      first_share = result[0]
+      result.continuation_token.wont_equal("")
+
+      result = subject.list_shares({ :max_results => 2, :marker => result.continuation_token })
+      result.length.must_equal 2
+      result[0].name.wont_equal first_share.name
+    end
+
+    it 'returns metadata if the :metadata=>true option is used' do
+      result = subject.list_shares({ :metadata => true })
+
+      found = 0
+      result.each { |c|
+        if share_names.include? c.name
+          found += 1 
+          metadata.each { |k,v|
+            c.metadata.must_include k.downcase
+            c.metadata[k.downcase].must_equal v
+          }
+        end
+      }
+      found.must_equal share_names.length
+    end
+  end
+end

--- a/test/integration/file/share_acl_test.rb
+++ b/test/integration/file/share_acl_test.rb
@@ -1,0 +1,75 @@
+#-------------------------------------------------------------------------
+# # Copyright (c) Microsoft and contributors. All rights reserved.
+#
+# The MIT License(MIT)
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#--------------------------------------------------------------------------
+require 'integration/test_helper'
+require "azure/storage/service/signed_identifier"
+
+describe Azure::Storage::File::FileService do
+  subject { Azure::Storage::File::FileService.new }
+  after { ShareNameHelper.clean }
+  
+  describe '#set/get_share_acl' do
+    let(:share_name) { ShareNameHelper.name }
+    let(:public_access_level) { :share.to_s }
+    let(:identifiers) {
+      identifier = Azure::Storage::Service::SignedIdentifier.new
+      identifier.id = "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI="
+      identifier.access_policy.start = "2009-09-28T08:49:37.0000000Z"
+      identifier.access_policy.expiry = "2009-09-29T08:49:37.0000000Z"
+      identifier.access_policy.permission = "rwd"
+      [identifier]
+    }
+    before { 
+      subject.create_share share_name
+    }
+
+    it 'sets and gets the ACL for the share' do
+      share, acl = subject.set_share_acl share_name, { :signed_identifiers => identifiers }
+      share.wont_be_nil
+      share.name.must_equal share_name
+      acl.length.must_equal identifiers.length
+      acl.first.id.must_equal identifiers.first.id
+      acl.first.access_policy.start.must_equal identifiers.first.access_policy.start
+      acl.first.access_policy.expiry.must_equal identifiers.first.access_policy.expiry
+      acl.first.access_policy.permission.must_equal identifiers.first.access_policy.permission
+
+      share, acl = subject.get_share_acl share_name
+      share.wont_be_nil
+      share.name.must_equal share_name
+      acl.length.must_equal identifiers.length
+      acl.first.id.must_equal identifiers.first.id
+      acl.first.access_policy.start.must_equal identifiers.first.access_policy.start
+      acl.first.access_policy.expiry.must_equal identifiers.first.access_policy.expiry
+      acl.first.access_policy.permission.must_equal identifiers.first.access_policy.permission
+    end
+
+    it 'errors if the share does not exist' do
+      assert_raises(Azure::Core::Http::HTTPError) do
+        subject.get_share_acl FileNameHelper.name
+      end
+      assert_raises(Azure::Core::Http::HTTPError) do
+        subject.set_share_acl FileNameHelper.name, { :identifiers => identifiers }
+      end
+    end
+  end
+end

--- a/test/integration/file/share_metadata_test.rb
+++ b/test/integration/file/share_metadata_test.rb
@@ -1,0 +1,63 @@
+#-------------------------------------------------------------------------
+# # Copyright (c) Microsoft and contributors. All rights reserved.
+#
+# The MIT License(MIT)
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#--------------------------------------------------------------------------
+require 'integration/test_helper'
+
+describe Azure::Storage::File::FileService do
+  let(:user_agent_prefix) { 'azure_storage_ruby_integration_test' }
+  subject { 
+    Azure::Storage::File::FileService.new { |headers|
+      headers['User-Agent'] = "#{user_agent_prefix}; #{headers['User-Agent']}"
+    }
+  }
+  after { ShareNameHelper.clean }
+  
+  describe '#set/get_share_metadata' do
+    let(:share_name) { ShareNameHelper.name }
+    let(:metadata) { { "CustomMetadataProperty"=>"CustomMetadataValue" } }
+    before { 
+      subject.create_share share_name
+    }
+
+    it 'sets and gets custom metadata for the share' do
+      result = subject.set_share_metadata share_name, metadata
+      result.must_be_nil
+      share = subject.get_share_metadata share_name
+      share.wont_be_nil
+      share.name.must_equal share_name
+      metadata.each { |k,v|
+        share.metadata.must_include k.downcase
+        share.metadata[k.downcase].must_equal v
+      }
+    end
+
+    it 'errors if the share does not exist' do
+      assert_raises(Azure::Core::Http::HTTPError) do
+        subject.get_share_metadata FileNameHelper.name
+      end
+      assert_raises(Azure::Core::Http::HTTPError) do
+        subject.set_share_metadata FileNameHelper.name, metadata
+      end
+    end
+  end
+end

--- a/test/integration/file/share_properties_test.rb
+++ b/test/integration/file/share_properties_test.rb
@@ -1,0 +1,85 @@
+#-------------------------------------------------------------------------
+# # Copyright (c) Microsoft and contributors. All rights reserved.
+#
+# The MIT License(MIT)
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#--------------------------------------------------------------------------
+require 'integration/test_helper'
+
+describe Azure::Storage::File::FileService do
+  subject { Azure::Storage::File::FileService.new }
+  after { ShareNameHelper.clean }
+  
+  describe '#get_share_properties' do
+    let(:share_name) { ShareNameHelper.name }
+    let(:metadata) { { "CustomMetadataProperty"=>"CustomMetadataValue" } }
+
+    it 'gets properties and custom metadata for the share' do
+      share = subject.create_share share_name, { :metadata => metadata }
+      properties = share.properties
+      
+      share = subject.get_share_properties share_name
+      share.wont_be_nil
+      share.name.must_equal share_name
+      share.properties[:etag].must_equal properties[:etag]
+      share.properties[:last_modified].must_equal properties[:last_modified]
+
+      metadata.each { |k,v|
+        share.metadata.must_include k.downcase
+        share.metadata[k.downcase].must_equal v
+      }
+    end
+
+    it 'errors if the share does not exist' do
+      assert_raises(Azure::Core::Http::HTTPError) do
+        subject.get_share_properties FileNameHelper.name
+      end
+    end
+  end
+
+  describe '#set_share_properties' do
+    let(:share_name) { FileNameHelper.name }
+    let(:share_quota) { 100 }
+    let(:metadata) { { "CustomMetadataProperty"=>"CustomMetadataValue" } }
+
+    it 'sets properties for the share' do
+      share = subject.create_share share_name, { :metadata => metadata }
+      properties = share.properties
+
+      share = subject.set_share_properties share_name, {:quota => share_quota}
+      share.must_be_nil
+
+      share = subject.get_share_properties share_name
+      share.name.must_equal share_name
+      share.quota.must_equal share_quota
+
+      metadata.each { |k,v|
+        share.metadata.must_include k.downcase
+        share.metadata[k.downcase].must_equal v
+      }
+    end
+
+    it 'errors if the share does not exist' do
+      assert_raises(Azure::Core::Http::HTTPError) do
+        subject.set_share_properties FileNameHelper.name
+      end
+    end
+  end
+end

--- a/test/integration/file/share_stats_test.rb
+++ b/test/integration/file/share_stats_test.rb
@@ -1,0 +1,49 @@
+#-------------------------------------------------------------------------
+# # Copyright (c) Microsoft and contributors. All rights reserved.
+#
+# The MIT License(MIT)
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#--------------------------------------------------------------------------
+require 'integration/test_helper'
+
+describe Azure::Storage::File::FileService do
+  subject { Azure::Storage::File::FileService.new }
+  after { ShareNameHelper.clean }
+  
+  describe '#get_share_stats' do
+    let(:share_name) { ShareNameHelper.name }
+
+    it 'gets acl and custom metadata for the share' do
+      share = subject.create_share share_name
+      properties = share.properties
+
+      share = subject.get_share_stats share_name
+      share.wont_be_nil
+      share.name.must_equal share_name
+      share.usage.must_equal 0
+    end
+
+    it 'errors if the share does not exist' do
+      assert_raises(Azure::Core::Http::HTTPError) do
+        subject.get_share_properties FileNameHelper.name
+      end
+    end
+  end
+end

--- a/test/integration/test_helper.rb
+++ b/test/integration/test_helper.rb
@@ -28,6 +28,4 @@ Azure::Storage.configure do |config|
   config.storage_access_key       = ENV.fetch('AZURE_STORAGE_ACCESS_KEY')
   config.storage_account_name     = ENV.fetch('AZURE_STORAGE_ACCOUNT')
   Azure::Storage.client(:storage_account_name => config.storage_account_name, :storage_access_key => config.storage_access_key)
-  require "azure/core/http/debug_filter"
-  Azure::Storage.client.blob_client.with_filter Azure::Core::Http::DebugFilter.new
 end

--- a/test/support/name_generator.rb
+++ b/test/support/name_generator.rb
@@ -69,6 +69,17 @@ QueueNameHelper = NameGenerator.new do |name|
   end
 end
 
+ShareNameHelper = NameGenerator.new do |name|
+  svc = Azure::Storage::File::FileService.new
+  begin
+    svc.delete_share name
+  rescue
+  end
+end
+
+FileNameHelper = NameGenerator.new do
+end
+
 ServiceBusRelayNameHelper = NameGenerator.new do |name|
   svc = Azure::ServiceBus::ServiceBusService.new
   begin

--- a/test/unit/blob/blob_service_test.rb
+++ b/test/unit/blob/blob_service_test.rb
@@ -527,7 +527,7 @@ describe Azure::Storage::Blob::BlobService do
         subject.list_blobs container_name
       end
 
-      it 'returns a list of containers for the account' do
+      it 'returns a list of blobs for the container' do
         result = subject.list_blobs container_name
         result.must_be_kind_of Azure::Service::EnumerationResults
       end
@@ -1202,7 +1202,7 @@ describe Azure::Storage::Blob::BlobService do
           subject.list_blob_blocks container_name, blob_name
         end
 
-        it 'returns a list of containers for the account' do
+        it 'returns a list of blocks for the block blob' do
           result = subject.list_blob_blocks container_name, blob_name
           result.must_be_kind_of Array
           result.first.must_be_kind_of Azure::Storage::Blob::Block
@@ -1267,7 +1267,7 @@ describe Azure::Storage::Blob::BlobService do
           subject.list_page_blob_ranges container_name, blob_name
         end
 
-        it 'returns a list of containers for the account' do
+        it 'returns a list of ranges for the page blob' do
           result = subject.list_page_blob_ranges container_name, blob_name
           result.must_be_kind_of Array
           result.first.must_be_kind_of Array

--- a/test/unit/file/file_service_test.rb
+++ b/test/unit/file/file_service_test.rb
@@ -1300,7 +1300,7 @@ describe Azure::Storage::File::FileService do
     describe '#copy_file' do
       let(:verb) { :put }
       let(:source_share_name) { 'source-share-name' }
-      let(:source_directory_path) { 'source-direcotry-path' }
+      let(:source_directory_path) { 'source-directory-path' }
       let(:source_file_name) { 'source-file-name' }
       let(:source_uri) { URI.parse('http://dummy.uri/source') }
 

--- a/test/unit/file/file_service_test.rb
+++ b/test/unit/file/file_service_test.rb
@@ -1,0 +1,1382 @@
+#-------------------------------------------------------------------------
+# # Copyright (c) Microsoft and contributors. All rights reserved.
+#
+# The MIT License(MIT)
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#--------------------------------------------------------------------------
+require 'test_helper'
+require 'unit/test_helper'
+require 'azure/storage/file/file_service'
+require 'azure/storage/file/serialization'
+require 'azure/storage/file/share'
+require 'azure/storage/file/directory'
+require 'azure/storage/file/file'
+require 'azure/storage/service/signed_identifier'
+
+describe Azure::Storage::File::FileService do
+  let(:user_agent_prefix) { 'azure_storage_ruby_unit_test' }
+  subject { 
+    Azure::Storage::File::FileService.new { |headers|
+      headers['User-Agent'] = "#{user_agent_prefix}; #{headers['User-Agent']}"
+    }
+  }
+  let(:serialization) { Azure::Storage::File::Serialization }
+  let(:uri) { URI.parse 'http://foo.com' }
+  let(:query) { {} }
+  let(:x_ms_version) { Azure::Storage::Default::STG_VERSION }
+  let(:user_agent) { Azure::Storage::Default::USER_AGENT }
+  let(:request_headers) { {'x-ms-version' => x_ms_version, 'User-Agent' => "#{user_agent_prefix}; #{user_agent}"} }
+  let(:request_body) { 'request-body' }
+
+  let(:response_headers) { {} }
+  let(:response_body) { mock() }
+  let(:response) { mock() }
+
+  let(:share_name) { 'share-name' }
+  let(:directory_path) { 'directory_path' }
+
+  before {
+    response.stubs(:body).returns(response_body)
+    response.stubs(:headers).returns(response_headers)
+  }
+
+  describe '#list_shares' do
+    let(:verb) { :get }
+    let(:shares_enumeration_result) { Azure::Service::EnumerationResults.new }
+
+    before {
+      subject.stubs(:shares_uri).with({}).returns(uri)
+      subject.stubs(:call).with(verb, uri, nil, {}, {}).returns(response)
+      serialization.stubs(:share_enumeration_results_from_xml).with(response_body).returns(shares_enumeration_result)
+    }
+
+    it 'assembles a URI for the request' do
+      subject.expects(:shares_uri).with({}).returns(uri)
+      subject.list_shares
+    end
+
+    it 'calls StorageService#call with the prepared request' do
+      subject.list_shares
+    end
+
+    it 'deserializes the response' do
+      serialization.expects(:share_enumeration_results_from_xml).with(response_body).returns(shares_enumeration_result)
+      subject.list_shares
+    end
+
+    it 'returns a list of containers for the account' do
+      result = subject.list_shares
+      result.must_be_kind_of Azure::Service::EnumerationResults
+    end
+
+    describe 'when the options Hash is used' do
+      before {
+        serialization.expects(:share_enumeration_results_from_xml).with(response_body).returns(shares_enumeration_result)
+      }
+
+      it 'modifies the URI query parameters when provided a :prefix value' do
+        query = {'prefix' => 'pre'}
+        subject.expects(:shares_uri).with(query).returns(uri)
+
+        options = {:prefix => 'pre'}
+        subject.expects(:call).with(:get, uri, nil, {}, options).returns(response)
+        subject.list_shares options
+      end
+
+      it 'modifies the URI query parameters when provided a :marker value' do
+        query = {'marker' => 'mark'}
+        subject.expects(:shares_uri).with(query).returns(uri)
+
+        options = {:marker => 'mark'}
+        subject.expects(:call).with(:get, uri, nil, {}, options).returns(response)
+        subject.list_shares options
+      end
+
+      it 'modifies the URI query parameters when provided a :max_results value' do
+        query = {'maxresults' => '5'}
+        subject.expects(:shares_uri).with(query).returns(uri)
+
+        options = {:max_results => 5}
+        subject.expects(:call).with(:get, uri, nil, {}, options).returns(response)
+        subject.list_shares options
+      end
+
+      it 'modifies the URI query parameters when provided a :metadata value' do
+        query = {'include' => 'metadata'}
+        subject.expects(:shares_uri).with(query).returns(uri)
+
+        options = {:metadata => true}
+        subject.expects(:call).with(:get, uri, nil, {}, options).returns(response)
+        subject.list_shares options
+      end
+
+      it 'modifies the URI query parameters when provided a :timeout value' do
+        query = {'timeout' => '37'}
+        subject.expects(:shares_uri).with(query).returns(uri)
+
+        options = {:timeout => 37}
+        subject.expects(:call).with(:get, uri, nil, {}, options).returns(response)
+        subject.list_shares options
+      end
+
+      it 'does not modify the URI query parameters when provided an unknown value' do
+        subject.expects(:shares_uri).with({}).returns(uri)
+
+        options = {:unknown_key => 'some_value'}
+        subject.expects(:call).with(:get, uri, nil, {}, options).returns(response)
+        subject.list_shares options
+      end
+    end
+  end
+
+  describe 'share functions' do
+    let(:share) { Azure::Storage::File::Share::Share.new }
+
+    describe '#create_share' do
+      let(:verb) { :put }
+      before {
+        subject.stubs(:share_uri).with(share_name, {}).returns(uri)
+        subject.stubs(:call).with(verb, uri, nil, request_headers, {}).returns(response)
+        serialization.stubs(:share_from_headers).with(response_headers).returns(share)
+      }
+
+      it 'assembles a URI for the request' do
+        subject.expects(:share_uri).with(share_name, {}).returns(uri)
+        subject.create_share share_name
+      end
+
+      it 'calls StorageService#call with the prepared request' do
+        subject.expects(:call).with(verb, uri, nil, request_headers, {}).returns(response)
+        subject.create_share share_name
+      end
+
+      it 'deserializes the response' do
+        serialization.expects(:share_from_headers).with(response_headers).returns(share)
+        subject.create_share share_name
+      end
+
+      it 'returns a new share' do
+        result = subject.create_share share_name
+
+        result.must_be_kind_of Azure::Storage::File::Share::Share
+        result.name.must_equal share_name
+      end
+
+      describe 'when optional metadata parameter is used' do
+        let(:share_metadata) {
+          {
+            'MetadataKey' => 'MetaDataValue',
+            'MetadataKey1' => 'MetaDataValue1'
+          }
+        }
+
+        before do
+          request_headers = {
+            'x-ms-meta-MetadataKey' => 'MetaDataValue',
+            'x-ms-meta-MetadataKey1' => 'MetaDataValue1',
+            'x-ms-version' => x_ms_version,
+            'User-Agent' => "#{user_agent_prefix}; #{user_agent}"
+          }
+          subject.stubs(:share_uri).with(share_name, {}).returns(uri)
+          serialization.stubs(:share_from_headers).with(response_headers).returns(share)
+          subject.stubs(:call).with(verb, uri, nil, request_headers, {}).returns(response)
+        end
+
+        it 'adds metadata to the request headers' do
+          subject.stubs(:call).with(verb, uri, nil, request_headers, share_metadata).returns(response)
+          subject.create_share share_name, share_metadata
+        end
+      end
+    end
+
+    describe '#delete_share' do
+      let(:verb) { :delete }
+      before {
+        response.stubs(:success?).returns(true)
+        subject.stubs(:share_uri).with(share_name, {}).returns(uri)
+        subject.stubs(:call).with(verb, uri, nil, {}, {}).returns(response)
+      }
+
+      it 'assembles a URI for the request' do
+        subject.expects(:share_uri).with(share_name, {}).returns(uri)
+        subject.delete_share share_name
+      end
+
+      it 'calls StorageService#call with the prepared request' do
+        subject.expects(:call).with(verb, uri, nil, {}, {}).returns(response)
+        subject.delete_share share_name
+      end
+
+      it 'returns nil on success' do
+        result = subject.delete_share share_name
+        result.must_equal nil
+      end
+    end
+
+    describe '#set_share_properties' do
+        let(:verb) { :put }
+        let(:request_headers) { {'x-ms-version' => x_ms_version, 'User-Agent' => "#{user_agent_prefix}; #{user_agent}"} }
+
+        before {
+          query.update({'comp' => 'properties'})
+          response.stubs(:success?).returns(true)
+          subject.stubs(:share_uri).with(share_name, query).returns(uri)
+          subject.stubs(:call).with(verb, uri, nil, request_headers, {}).returns(response)
+        }
+
+        it 'assembles a URI for the request' do
+          subject.expects(:share_uri).with(share_name, query).returns(uri)
+          subject.set_share_properties share_name
+        end
+
+        it 'calls StorageService#call with the prepared request' do
+          subject.expects(:call).with(verb, uri, nil, request_headers, {}).returns(response)
+          subject.set_share_properties share_name
+        end
+
+        it 'returns nil on success' do
+          result = subject.set_share_properties share_name
+          result.must_equal nil
+        end
+
+        describe 'when the options Hash is used' do
+          it 'modifies the request headers when provided a :content_type value' do
+            request_headers['x-ms-share-quota'] = '50'
+            options = {:quota => 50}
+            subject.stubs(:call).with(verb, uri, nil, request_headers, options).returns(response)
+            subject.set_share_properties share_name, options
+          end
+
+          it 'modifies the URI query parameters when provided a :timeout value' do
+            query.merge!({'timeout' => '37'})
+            subject.stubs(:share_uri).with(share_name, query).returns(uri)
+
+            options = {:timeout => 37}
+            subject.expects(:call).with(verb, uri, nil, request_headers, options).returns(response)
+            subject.set_share_properties share_name, options
+          end
+
+          it 'does not modify the request headers when provided an unknown value' do
+            options = {:unknown_key => 'some_value'}
+            subject.stubs(:call).with(verb, uri, nil, request_headers, options).returns(response)
+            subject.set_share_properties share_name, options
+          end
+        end
+      end
+
+    describe '#get_share_properties' do
+      let(:verb) { :get }
+      let(:share_properties) { {} }
+
+      before {
+        share.properties = share_properties
+        response_headers = {}
+        subject.stubs(:share_uri).with(share_name, {}).returns(uri)
+        subject.stubs(:call).with(verb, uri, nil, {}, {}).returns(response)
+        serialization.stubs(:share_from_headers).with(response_headers).returns(share)
+      }
+
+      it 'assembles a URI for the request' do
+        subject.expects(:share_uri).with(share_name, {}).returns(uri)
+        subject.get_share_properties share_name
+      end
+
+      it 'calls StorageService#call with the prepared request' do
+        subject.expects(:call).with(verb, uri, nil, {}, {}).returns(response)
+        subject.get_share_properties share_name
+      end
+
+      it 'deserializes the response' do
+        serialization.expects(:share_from_headers).with(response_headers).returns(share)
+        subject.get_share_properties share_name
+      end
+
+      it "returns a share, with it's properties attribute populated" do
+        result = subject.get_share_properties share_name
+        result.must_be_kind_of Azure::Storage::File::Share::Share
+        result.name.must_equal share_name
+        result.properties.must_equal share_properties
+      end
+    end
+
+    describe '#get_share_metadata' do
+      let(:verb) { :get }
+      let(:share_metadata) { {'MetadataKey' => 'MetaDataValue', 'MetadataKey1' => 'MetaDataValue1'} }
+      let(:response_headers) { {'x-ms-meta-MetadataKey' => 'MetaDataValue', 'x-ms-meta-MetadataKey1' => 'MetaDataValue1'} }
+
+      before {
+        query.update({'comp' => 'metadata'})
+        response.stubs(:headers).returns(response_headers)
+        subject.stubs(:share_uri).with(share_name, query).returns(uri)
+        subject.stubs(:call).with(verb, uri, nil, {}, {}).returns(response)
+
+        share.metadata = share_metadata
+        serialization.stubs(:share_from_headers).with(response_headers).returns(share)
+      }
+
+      it 'assembles a URI for the request' do
+        subject.expects(:share_uri).with(share_name, query).returns(uri)
+        subject.get_share_metadata share_name
+      end
+
+      it 'calls StorageService#call with the prepared request' do
+        subject.expects(:call).with(verb, uri, nil, {}, {}).returns(response)
+        subject.get_share_metadata share_name
+      end
+
+      it 'deserializes the response' do
+        serialization.expects(:share_from_headers).with(response_headers).returns(share)
+        subject.get_share_metadata share_name
+      end
+
+      it "returns a share, with it's metadata attribute populated" do
+        result = subject.get_share_metadata share_name
+        result.must_be_kind_of Azure::Storage::File::Share::Share
+        result.name.must_equal share_name
+        result.metadata.must_equal share_metadata
+      end
+    end
+
+    describe '#set_share_metadata' do
+      let(:verb) { :put }
+      let(:share_metadata) { {'MetadataKey' => 'MetaDataValue', 'MetadataKey1' => 'MetaDataValue1'} }
+      let(:request_headers) {
+        {'x-ms-meta-MetadataKey' => 'MetaDataValue',
+         'x-ms-meta-MetadataKey1' => 'MetaDataValue1',
+         'x-ms-version' => x_ms_version,
+         'User-Agent' => "#{user_agent_prefix}; #{user_agent}"
+         }
+      }
+
+      before {
+        query.update({'comp' => 'metadata'})
+        response.stubs(:success?).returns(true)
+        subject.stubs(:share_uri).with(share_name, query).returns(uri)
+        subject.stubs(:call).with(verb, uri, nil, request_headers, {}).returns(response)
+      }
+
+      it 'assembles a URI for the request' do
+        subject.expects(:share_uri).with(share_name, query).returns(uri)
+        subject.set_share_metadata share_name, share_metadata
+      end
+
+      it 'calls StorageService#call with the prepared request' do
+        subject.expects(:call).with(verb, uri, nil, request_headers, {}).returns(response)
+        subject.set_share_metadata share_name, share_metadata
+      end
+
+      it 'returns nil on success' do
+        result = subject.set_share_metadata share_name, share_metadata
+        result.must_equal nil
+      end
+    end
+
+    describe '#get_share_acl' do
+      let(:verb) { :get }
+      let(:signed_identifier) { Azure::Storage::Service::SignedIdentifier.new }
+      let(:signed_identifiers) { [signed_identifier] }
+
+      before {
+        query.update({'comp' => 'acl'})
+        response.stubs(:headers).returns({})
+        response_body.stubs(:length).returns(37)
+        subject.stubs(:share_uri).with(share_name, query).returns(uri)
+        subject.stubs(:call).with(verb, uri, nil, {}, {}).returns(response)
+
+        serialization.stubs(:share_from_headers).with(response_headers).returns(share)
+        serialization.stubs(:signed_identifiers_from_xml).with(response_body).returns(signed_identifiers)
+      }
+
+      it 'assembles a URI for the request' do
+        subject.expects(:share_uri).with(share_name, query).returns(uri)
+        subject.get_share_acl share_name
+      end
+
+      it 'calls StorageService#call with the prepared request' do
+        subject.expects(:call).with(verb, uri, nil, {}, {}).returns(response)
+        subject.get_share_acl share_name
+      end
+
+      it 'deserializes the response' do
+        serialization.expects(:share_from_headers).with(response_headers).returns(share)
+        serialization.expects(:signed_identifiers_from_xml).with(response_body).returns(signed_identifiers)
+        subject.get_share_acl share_name
+      end
+
+      it 'returns a share and an ACL' do
+        returned_share, returned_acl = subject.get_share_acl share_name
+
+        returned_share.must_be_kind_of Azure::Storage::File::Share::Share
+        returned_share.name.must_equal share_name
+
+        returned_acl.must_be_kind_of Array
+        returned_acl[0].must_be_kind_of Azure::Storage::Service::SignedIdentifier
+      end
+    end
+
+    describe '#set_share_acl' do
+      let(:verb) { :put }
+
+      before {
+        query.update({'comp' => 'acl'})
+
+        response.stubs(:headers).returns({})
+        subject.stubs(:share_uri).with(share_name, query).returns(uri)
+        subject.stubs(:call).with(verb, uri, nil, request_headers, {}).returns(response)
+        serialization.stubs(:share_from_headers).with(response_headers).returns(share)
+      }
+
+      it 'assembles a URI for the request' do
+        subject.expects(:share_uri).with(share_name, query).returns(uri)
+        subject.set_share_acl share_name
+      end
+
+      it 'calls StorageService#call with the prepared request' do
+        subject.expects(:call).with(verb, uri, nil, request_headers, {}).returns(response)
+        subject.set_share_acl share_name
+      end
+
+      it 'deserializes the response' do
+        serialization.expects(:share_from_headers).with(response_headers).returns(share)
+        subject.set_share_acl share_name
+      end
+
+      it 'returns a share and an ACL' do
+        returned_share, returned_acl = subject.set_share_acl share_name
+
+        returned_share.must_be_kind_of Azure::Storage::File::Share::Share
+        returned_share.name.must_equal share_name
+
+        returned_acl.must_be_kind_of Array
+      end
+
+      describe 'when the signed_identifiers parameter is set' do
+        let(:signed_identifier) { Azure::Storage::Service::SignedIdentifier.new }
+        let(:signed_identifiers) { [signed_identifier] }
+        
+        before {
+          subject.stubs(:call).with(verb, uri, request_body, request_headers, {}).returns(response)
+          serialization.stubs(:signed_identifiers_to_xml).with(signed_identifiers).returns(request_body)
+        }
+
+        it 'serializes the request contents' do
+          serialization.expects(:signed_identifiers_to_xml).with(signed_identifiers).returns(request_body)
+          options = {:signed_identifiers => signed_identifiers}
+          subject.stubs(:call).with(verb, uri, request_body, request_headers, options).returns(response)
+          subject.set_share_acl share_name, options
+        end
+
+        it 'returns a share and an ACL' do
+          options = {:signed_identifiers => signed_identifiers}
+          subject.stubs(:call).with(verb, uri, request_body, request_headers, options).returns(response)
+          returned_share, returned_acl = subject.set_share_acl share_name, options
+
+          returned_share.must_be_kind_of Azure::Storage::File::Share::Share
+          returned_share.name.must_equal share_name
+
+          returned_acl.must_be_kind_of Array
+          returned_acl[0].must_be_kind_of Azure::Storage::Service::SignedIdentifier
+        end
+      end
+    end
+
+    describe '#get_share_stats' do
+      let(:verb) { :get }
+      let(:share_stats) { 10 }
+
+      before {
+        response_headers = {}
+        query.update({'comp' => 'stats'})
+        subject.stubs(:share_uri).with(share_name, query).returns(uri)
+        subject.stubs(:call).with(verb, uri, nil, {}, {}).returns(response)
+        serialization.stubs(:share_from_headers).with(response_headers).returns(share)
+        serialization.stubs(:share_stats_from_xml).with(response_body).returns(share_stats)
+      }
+
+      it 'assembles a URI for the request' do
+        subject.expects(:share_uri).with(share_name, query).returns(uri)
+        subject.get_share_stats share_name
+      end
+
+      it 'calls StorageService#call with the prepared request' do
+        subject.expects(:call).with(verb, uri, nil, {}, {}).returns(response)
+        subject.get_share_stats share_name
+      end
+
+      it 'deserializes the response' do
+        serialization.expects(:share_from_headers).with(response_headers).returns(share)
+        subject.get_share_stats share_name
+      end
+
+      it "returns a share, with it's properties attribute populated" do
+        serialization.expects(:share_stats_from_xml).with(response_body).returns(share_stats)
+        result = subject.get_share_stats share_name
+        result.must_be_kind_of Azure::Storage::File::Share::Share
+        result.name.must_equal share_name
+        result.usage.must_equal share_stats
+      end
+    end
+  end
+
+  describe 'directory functions' do
+    let(:directory) { Azure::Storage::File::Directory::Directory.new }
+
+    describe '#list_directories_and_files' do
+      let(:verb) { :get }
+      let(:query) { {'comp' => 'list'} }
+      let(:directories_and_files_enumeration_results) { Azure::Service::EnumerationResults.new }
+
+      before {
+        subject.stubs(:directory_uri).with(share_name, directory_path, query).returns(uri)
+        subject.stubs(:call).with(verb, uri, nil, {}, {}).returns(response)
+        response.stubs(:success?).returns(true)
+        serialization.stubs(:directories_and_files_enumeration_results_from_xml).with(response_body).returns(directories_and_files_enumeration_results)
+      }
+
+      it 'assembles a URI for the request' do
+        subject.expects(:directory_uri).with(share_name, directory_path, query).returns(uri)
+        subject.list_directories_and_files share_name, directory_path
+      end
+
+      it 'calls StorageService#call with the prepared request' do
+        subject.expects(:call).with(verb, uri, nil, {}, {}).returns(response)
+        subject.list_directories_and_files share_name, directory_path
+      end
+
+      it 'deserializes the response' do
+        serialization.expects(:directories_and_files_enumeration_results_from_xml).with(response_body).returns(directories_and_files_enumeration_results)
+        subject.list_directories_and_files share_name, directory_path
+      end
+
+      it 'returns a list of containers for the account' do
+        result = subject.list_directories_and_files share_name, directory_path
+        result.must_be_kind_of Azure::Service::EnumerationResults
+      end
+
+      describe 'when the options Hash is used' do
+        before {
+          response.expects(:success?).returns(true)
+          serialization.expects(:directories_and_files_enumeration_results_from_xml).with(response_body).returns(directories_and_files_enumeration_results)
+          subject.expects(:directory_uri).with(share_name, directory_path, query).returns(uri)
+        }
+
+        it 'modifies the URI query parameters when provided a :marker value' do
+          query['marker'] = 'mark'
+          options = {:marker => 'mark'}
+          subject.expects(:call).with(:get, uri, nil, {}, options).returns(response)
+          subject.list_directories_and_files share_name, directory_path, options
+        end
+
+        it 'modifies the URI query parameters when provided a :max_results value' do
+          query['maxresults'] = '5'
+          options = {:max_results => 5}
+          subject.expects(:call).with(:get, uri, nil, {}, options).returns(response)
+          subject.list_directories_and_files share_name, directory_path, options
+        end
+
+        it 'modifies the URI query parameters when provided a :timeout value' do
+          query['timeout'] = '37'
+          options = {:timeout => 37}
+          subject.expects(:call).with(:get, uri, nil, {}, options).returns(response)
+          subject.list_directories_and_files share_name, directory_path, options
+        end
+
+        it 'does not modify the URI query parameters when provided an unknown value' do
+          options = {:unknown_key => 'some_value'}
+          subject.expects(:call).with(:get, uri, nil, {}, options).returns(response)
+          subject.list_directories_and_files share_name, directory_path, options
+        end
+      end
+    end
+
+    describe '#get_directory_properties' do
+      let(:verb) { :get }
+      let(:directory_properties) { {} }
+
+      before {
+        directory.properties = directory_properties
+        response_headers = {}
+        subject.stubs(:directory_uri).with(share_name, directory_path, {}).returns(uri)
+        subject.stubs(:call).with(verb, uri, nil, {}, {}).returns(response)
+        serialization.stubs(:directory_from_headers).with(response_headers).returns(directory)
+      }
+
+      it 'assembles a URI for the request' do
+        subject.expects(:directory_uri).with(share_name, directory_path, {}).returns(uri)
+        subject.get_directory_properties share_name, directory_path
+      end
+
+      it 'calls StorageService#call with the prepared request' do
+        subject.expects(:call).with(verb, uri, nil, {}, {}).returns(response)
+        subject.get_directory_properties share_name, directory_path
+      end
+
+      it 'deserializes the response' do
+        serialization.expects(:directory_from_headers).with(response_headers).returns(directory)
+        subject.get_directory_properties share_name, directory_path
+      end
+
+      it "returns a share, with it's properties attribute populated" do
+        result = subject.get_directory_properties share_name, directory_path
+        result.must_be_kind_of Azure::Storage::File::Directory::Directory
+        result.name.must_equal directory_path
+        result.properties.must_equal directory_properties
+      end
+    end
+
+    describe '#get_directory_metadata' do
+      let(:verb) { :get }
+      let(:directory_metadata) { {'MetadataKey' => 'MetaDataValue', 'MetadataKey1' => 'MetaDataValue1'} }
+      let(:response_headers) { {'x-ms-meta-MetadataKey' => 'MetaDataValue', 'x-ms-meta-MetadataKey1' => 'MetaDataValue1'} }
+
+      before {
+        query.update({'comp' => 'metadata'})
+        response.stubs(:headers).returns(response_headers)
+        subject.stubs(:directory_uri).with(share_name, directory_path, query).returns(uri)
+        subject.stubs(:call).with(verb, uri, nil, {}, {}).returns(response)
+
+        directory.metadata = directory_metadata
+        serialization.stubs(:directory_from_headers).with(response_headers).returns(directory)
+      }
+
+      it 'assembles a URI for the request' do
+        subject.expects(:directory_uri).with(share_name, directory_path, query).returns(uri)
+        subject.get_directory_metadata share_name, directory_path
+      end
+
+      it 'calls StorageService#call with the prepared request' do
+        subject.expects(:call).with(verb, uri, nil, {}, {}).returns(response)
+        subject.get_directory_metadata share_name, directory_path
+      end
+
+      it 'deserializes the response' do
+        serialization.expects(:directory_from_headers).with(response_headers).returns(directory)
+        subject.get_directory_metadata share_name, directory_path
+      end
+
+      it "returns a directory, with it's metadata attribute populated" do
+        result = subject.get_directory_metadata share_name, directory_path
+        result.must_be_kind_of Azure::Storage::File::Directory::Directory
+        result.name.must_equal directory_path
+        result.metadata.must_equal directory_metadata
+      end
+    end
+
+    describe '#set_directory_metadata' do
+      let(:verb) { :put }
+      let(:directory_metadata) { {'MetadataKey' => 'MetaDataValue', 'MetadataKey1' => 'MetaDataValue1'} }
+      let(:request_headers) {
+        {'x-ms-meta-MetadataKey' => 'MetaDataValue',
+         'x-ms-meta-MetadataKey1' => 'MetaDataValue1',
+         'x-ms-version' => x_ms_version,
+         'User-Agent' => "#{user_agent_prefix}; #{user_agent}"
+         }
+      }
+
+      before {
+        query.update({'comp' => 'metadata'})
+        response.stubs(:success?).returns(true)
+        subject.stubs(:directory_uri).with(share_name, directory_path, query).returns(uri)
+        subject.stubs(:call).with(verb, uri, nil, request_headers, {}).returns(response)
+      }
+
+      it 'assembles a URI for the request' do
+        subject.expects(:directory_uri).with(share_name, directory_path, query).returns(uri)
+        subject.set_directory_metadata share_name, directory_path, directory_metadata
+      end
+
+      it 'calls StorageService#call with the prepared request' do
+        subject.expects(:call).with(verb, uri, nil, request_headers, {}).returns(response)
+        subject.set_directory_metadata share_name, directory_path, directory_metadata
+      end
+
+      it 'returns nil on success' do
+        result = subject.set_directory_metadata share_name, directory_path, directory_metadata
+        result.must_equal nil
+      end
+    end
+  end
+
+  describe 'file functions' do
+    let(:file_name) { 'file-name' }
+    let(:file) { Azure::Storage::File::File.new }
+
+    describe '#create_file' do
+      let(:verb) { :put }
+      let(:file_length) { 37 }
+      let(:request_headers) {
+        {
+          'x-ms-type' => 'file',
+          'Content-Length' => 0.to_s,
+          'x-ms-content-length' => file_length.to_s,
+          'x-ms-version' => x_ms_version,
+          'User-Agent' => "#{user_agent_prefix}; #{user_agent}"
+        }
+      }
+
+      before {
+        subject.stubs(:file_uri).with(share_name, directory_path, file_name, {}).returns(uri)
+        subject.stubs(:call).with(verb, uri, nil, request_headers, {}).returns(response)
+        serialization.stubs(:file_from_headers).with(response_headers).returns(file)
+      }
+
+      it 'assembles a URI for the request' do
+        subject.expects(:file_uri).with(share_name, directory_path, file_name, {}).returns(uri)
+        subject.create_file share_name, directory_path, file_name, file_length
+      end
+
+      it 'calls StorageService#call with the prepared request' do
+        subject.expects(:call).with(verb, uri, nil, request_headers, {}).returns(response)
+        subject.create_file share_name, directory_path, file_name, file_length
+      end
+
+      it 'returns a Blob on success' do
+        result = subject.create_file share_name, directory_path, file_name, file_length
+        result.must_be_kind_of Azure::Storage::File::File
+        result.must_equal file
+        result.name.must_equal file_name
+      end
+
+      describe 'when the options Hash is used' do
+        it 'modifies the request headers when provided a :content_type value' do
+          request_headers['x-ms-content-type'] = 'fct-value'
+          options = {:content_type => 'fct-value'}
+          subject.stubs(:call).with(verb, uri, nil, request_headers, options).returns(response)
+          subject.create_file share_name, directory_path, file_name, file_length, options
+        end
+
+        it 'modifies the request headers when provided a :content_encoding value' do
+          request_headers['x-ms-content-encoding'] = 'fce-value'
+          options = {:content_encoding => 'fce-value'}
+          subject.stubs(:call).with(verb, uri, nil, request_headers, options).returns(response)
+          subject.create_file share_name, directory_path, file_name, file_length, options
+        end
+
+        it 'modifies the request headers when provided a :content_language value' do
+          request_headers['x-ms-content-language'] = 'fcl-value'
+          options = {:content_language => 'fcl-value'}
+          subject.stubs(:call).with(verb, uri, nil, request_headers, options).returns(response)
+          subject.create_file share_name, directory_path, file_name, file_length, options
+        end
+
+        it 'modifies the request headers when provided a :content_md5 value' do
+          request_headers['x-ms-content-md5'] = 'cm-value'
+          options = {:content_md5 => 'cm-value'}
+          subject.stubs(:call).with(verb, uri, nil, request_headers, options).returns(response)
+          subject.create_file share_name, directory_path, file_name, file_length, options
+        end
+
+        it 'modifies the request headers when provided a :cache_control value' do
+          request_headers['x-ms-cache-control'] = 'fcc-value'
+          options = {:cache_control => 'fcc-value'}
+          subject.stubs(:call).with(verb, uri, nil, request_headers, options).returns(response)
+          subject.create_file share_name, directory_path, file_name, file_length, options
+        end
+        
+        it 'modifies the request headers when provided a :content_disposition value' do
+          request_headers['x-ms-content-disposition'] = 'fcd-value'
+          options = {:content_disposition => 'fcd-value'}
+          subject.stubs(:call).with(verb, uri, nil, request_headers, options).returns(response)
+          subject.create_file share_name, directory_path, file_name, file_length, options
+        end
+
+        it 'modifies the request headers when provided a :metadata value' do
+          request_headers['x-ms-meta-MetadataKey'] = 'MetaDataValue'
+          request_headers['x-ms-meta-MetadataKey1'] = 'MetaDataValue1'
+          options = {:metadata => {'MetadataKey' => 'MetaDataValue', 'MetadataKey1' => 'MetaDataValue1'}}
+          subject.stubs(:call).with(verb, uri, nil, request_headers, options).returns(response)
+          subject.create_file share_name, directory_path, file_name, file_length, options
+        end
+
+        it 'does not modify the request headers when provided an unknown value' do
+          options = {:unknown_key => 'some_value'}
+          subject.stubs(:call).with(verb, uri, nil, request_headers, options).returns(response)
+          subject.create_file share_name, directory_path, file_name, file_length, options
+        end
+      end
+    end
+
+    describe '#put_file_range' do
+      let(:verb) { :put }
+      let(:start_range) { 255 }
+      let(:end_range) { 512 }
+      let(:content) { 'some content' }
+      let(:query) { {'comp' => 'range'} }
+      let(:request_headers) {
+        {
+          'x-ms-write' => 'update',
+          'x-ms-range' => "bytes=#{start_range}-#{end_range}",
+          'x-ms-version' => x_ms_version,
+          'User-Agent' => "#{user_agent_prefix}; #{user_agent}"
+        }
+      }
+
+      before {
+        subject.stubs(:file_uri).with(share_name, directory_path, file_name, query).returns(uri)
+        subject.stubs(:call).with(verb, uri, content, request_headers, {}).returns(response)
+        serialization.stubs(:file_from_headers).with(response_headers).returns(file)
+      }
+
+      it 'assembles a URI for the request' do
+        subject.expects(:file_uri).with(share_name, directory_path, file_name, query).returns(uri)
+        subject.put_file_range share_name, directory_path, file_name, start_range, end_range, content
+      end
+
+      it 'calls StorageService#call with the prepared request' do
+        subject.expects(:call).with(verb, uri, content, request_headers, {}).returns(response)
+        subject.put_file_range share_name, directory_path, file_name, start_range, end_range, content
+      end
+
+      it 'returns a Blob on success' do
+        result = subject.put_file_range share_name, directory_path, file_name, start_range, end_range, content
+        result.must_be_kind_of Azure::Storage::File::File
+        result.must_equal file
+        result.name.must_equal file_name
+      end
+    end
+
+    describe '#clear_file_range' do
+      let(:verb) { :put }
+      let(:query) { {'comp' => 'range'} }
+      let(:start_range) { 255 }
+      let(:end_range) { 512 }
+      let(:request_headers) {
+        {
+          'x-ms-range' => "bytes=#{start_range}-#{end_range}",
+          'x-ms-write' => 'clear',
+          'x-ms-version' => x_ms_version,
+          'User-Agent' => "#{user_agent_prefix}; #{user_agent}"
+        }
+      }
+
+      before {
+        subject.stubs(:file_uri).with(share_name, directory_path, file_name, query).returns(uri)
+        subject.stubs(:call).with(verb, uri, nil, request_headers, {}).returns(response)
+        serialization.stubs(:file_from_headers).with(response_headers).returns(file)
+      }
+
+      it 'assembles a URI for the request' do
+        subject.expects(:file_uri).with(share_name, directory_path, file_name, query).returns(uri)
+        subject.clear_file_range share_name, directory_path, file_name, start_range, end_range
+      end
+
+      it 'calls StorageService#call with the prepared request' do
+        subject.expects(:call).with(verb, uri, nil, request_headers, {}).returns(response)
+        subject.clear_file_range share_name, directory_path, file_name, start_range, end_range
+      end
+
+      it 'returns a Blob on success' do
+        result = subject.clear_file_range share_name, directory_path, file_name, start_range, end_range
+        result.must_be_kind_of Azure::Storage::File::File
+        result.must_equal file
+        result.name.must_equal file_name
+      end
+
+      describe "when start_range is provided" do
+        let(:start_range){ 255 }
+        before { request_headers["x-ms-range"]="bytes=#{start_range}-" }
+
+        it "modifies the request headers with the desired range" do
+          subject.expects(:call).with(verb, uri, nil, request_headers, {}).returns(response)
+          subject.clear_file_range share_name, directory_path, file_name, start_range
+        end
+      end
+
+      describe "when end_range is provided" do
+        let(:end_range){ 512 }
+        before { request_headers["x-ms-range"]="bytes=0-#{end_range}" }
+
+        it "modifies the request headers with the desired range" do
+          subject.expects(:call).with(verb, uri, nil, request_headers, {}).returns(response)
+          subject.clear_file_range share_name, directory_path, file_name, nil, end_range
+        end
+      end
+
+      describe "when both start_range and end_range are provided" do
+        before { request_headers["x-ms-range"]="bytes=#{start_range}-#{end_range}" }
+
+        it "modifies the request headers with the desired range" do
+          subject.expects(:call).with(verb, uri, nil, request_headers, {}).returns(response)
+          subject.clear_file_range share_name, directory_path, file_name, start_range, end_range
+        end
+      end
+    end
+
+    describe '#list_file_ranges' do
+      let(:verb) { :get }
+      let(:query) { {'comp' => 'rangelist'} }
+      let(:range_list) { [[0, 511], [512, 1023]] }
+
+      before {
+        subject.stubs(:file_uri).with(share_name, directory_path, file_name, query).returns(uri)
+        subject.stubs(:call).with(verb, uri, nil, request_headers, {}).returns(response)
+        serialization.stubs(:range_list_from_xml).with(response_body).returns(range_list)
+      }
+
+      it 'assembles a URI for the request' do
+        subject.expects(:file_uri).with(share_name, directory_path, file_name, query).returns(uri)
+        subject.list_file_ranges share_name, directory_path, file_name
+      end
+
+      it 'calls StorageService#call with the prepared request' do
+        subject.expects(:call).with(verb, uri, nil, request_headers, {}).returns(response)
+        subject.list_file_ranges share_name, directory_path, file_name
+      end
+
+      it 'deserializes the response' do
+        serialization.expects(:range_list_from_xml).with(response_body).returns(range_list)
+        subject.list_file_ranges share_name, directory_path, file_name
+      end
+
+      it 'returns a list of ranges' do
+        file, result = subject.list_file_ranges share_name, directory_path, file_name
+        result.must_be_kind_of Array
+        result.first.must_be_kind_of Array
+        result.first.first.must_be_kind_of Integer
+        result.first.first.next.must_be_kind_of Integer
+      end
+
+      describe "when start_range is provided" do
+        let(:start_range){ 255 }
+        before { request_headers["x-ms-range"]="bytes=#{start_range}-" }
+
+        it "modifies the request headers with the desired range" do
+          subject.expects(:call).with(verb, uri, nil, request_headers, {:start_range => "#{start_range}".to_i}).returns(response)
+          subject.list_file_ranges share_name, directory_path, file_name, start_range: start_range
+        end
+      end
+
+      describe "when end_range is provided" do
+        let(:end_range){ 512 }
+        before { request_headers["x-ms-range"]="bytes=0-#{end_range}" }
+
+        it "modifies the request headers with the desired range" do
+          subject.expects(:call).with(verb, uri, nil, request_headers, {:start_range => 0, :end_range => "#{end_range}".to_i}).returns(response)
+          subject.list_file_ranges share_name, directory_path, file_name, start_range: nil, end_range: end_range
+        end
+      end
+
+      describe 'when both start_range and end_range are provided' do
+        let(:start_range) { 255 }
+        let(:end_range) { 512 }
+        let(:request_headers) { {'x-ms-version' => x_ms_version, 'User-Agent' => "#{user_agent_prefix}; #{user_agent}"} }
+
+        it 'modifies the request headers with the desired range' do
+          request_headers['x-ms-range'] = "bytes=#{start_range}-#{end_range}"
+          options = {:start_range => start_range, :end_range => end_range}
+          subject.expects(:call).with(verb, uri, nil, request_headers, options).returns(response)
+          subject.list_file_ranges share_name, directory_path, file_name, options
+        end
+      end
+    end
+    
+    describe '#resize_file' do
+      let(:verb) { :put }
+      let(:query) { {'comp' => 'properties'} }
+      let(:size) { 2048 }
+      let(:request_headers) { {'x-ms-version' => x_ms_version, 'User-Agent' => "#{user_agent_prefix}; #{user_agent}", 'x-ms-content-length' => size.to_s} }
+
+      before {
+        subject.stubs(:file_uri).with(share_name, directory_path, file_name, query).returns(uri)
+        subject.stubs(:call).with(verb, uri, nil, request_headers, {}).returns(response)
+      }
+
+      it 'resizes the file' do
+        subject.expects(:call).with(verb, uri, nil, request_headers, {:content_length => size}).returns(response)
+        subject.resize_file share_name, directory_path, file_name, size
+      end
+    end
+
+    describe '#set_file_properties' do
+      let(:verb) { :put }
+      let(:request_headers) { {'x-ms-version' => x_ms_version, 'User-Agent' => "#{user_agent_prefix}; #{user_agent}"} }
+
+      before {
+        query.update({'comp' => 'properties'})
+        response.stubs(:success?).returns(true)
+        subject.stubs(:file_uri).with(share_name, directory_path, file_name, query).returns(uri)
+        subject.stubs(:call).with(verb, uri, nil, request_headers, {}).returns(response)
+      }
+
+      it 'assembles a URI for the request' do
+        subject.expects(:file_uri).with(share_name, directory_path, file_name, query).returns(uri)
+        subject.set_file_properties share_name, directory_path, file_name
+      end
+
+      it 'calls StorageService#call with the prepared request' do
+        subject.expects(:call).with(verb, uri, nil, request_headers, {}).returns(response)
+        subject.set_file_properties share_name, directory_path, file_name
+      end
+
+      it 'returns nil on success' do
+        result = subject.set_file_properties share_name, directory_path, file_name
+        result.must_equal nil
+      end
+
+      describe 'when the options Hash is used' do
+        it 'modifies the request headers when provided a :content_type value' do
+          request_headers['x-ms-content-type'] = 'fct-value'
+          options = {:content_type => 'fct-value'}
+          subject.stubs(:call).with(verb, uri, nil, request_headers, options).returns(response)
+          subject.set_file_properties share_name, directory_path, file_name, options
+        end
+
+        it 'modifies the request headers when provided a :content_encoding value' do
+          request_headers['x-ms-content-encoding'] = 'fce-value'
+          options = {:content_encoding => 'fce-value'}
+          subject.stubs(:call).with(verb, uri, nil, request_headers, options).returns(response)
+          subject.set_file_properties share_name, directory_path, file_name, options
+        end
+
+        it 'modifies the request headers when provided a :content_language value' do
+          request_headers['x-ms-content-language'] = 'fcl-value'
+          options = {:content_language => 'fcl-value'}
+          subject.stubs(:call).with(verb, uri, nil, request_headers, options).returns(response)
+          subject.set_file_properties share_name, directory_path, file_name, options
+        end
+
+        it 'modifies the request headers when provided a :content_md5 value' do
+          request_headers['x-ms-content-md5'] = 'fcm-value'
+          options = {:content_md5 => 'fcm-value'}
+          subject.stubs(:call).with(verb, uri, nil, request_headers, options).returns(response)
+          subject.set_file_properties share_name, directory_path, file_name, options
+        end
+
+        it 'modifies the request headers when provided a :cache_control value' do
+          request_headers['x-ms-cache-control'] = 'fcc-value'
+          options = {:cache_control => 'fcc-value'}
+          subject.stubs(:call).with(verb, uri, nil, request_headers, options).returns(response)
+          subject.set_file_properties share_name, directory_path, file_name, options
+        end
+
+        it 'modifies the request headers when provided a :content_length value' do
+          request_headers['x-ms-content-length'] = '37'
+          options = {:content_length => 37.to_s}
+          subject.stubs(:call).with(verb, uri, nil, request_headers, options).returns(response)
+          subject.set_file_properties share_name, directory_path, file_name, options
+        end
+
+        it 'modifies the request headers when provided a :content_disposition value' do
+          request_headers['x-ms-content-disposition'] = 'fcd-value'
+          options = {:content_disposition => 'fcd-value'}
+          subject.stubs(:call).with(verb, uri, nil, request_headers, options).returns(response)
+          subject.set_file_properties share_name, directory_path, file_name, options
+        end
+
+        it 'does not modify the request headers when provided an unknown value' do
+          options = {:unknown_key => 'some_value'}
+          subject.stubs(:call).with(verb, uri, nil, request_headers, options).returns(response)
+          subject.set_file_properties share_name, directory_path, file_name, options
+        end
+      end
+    end
+
+    describe '#get_file_properties' do
+      let(:verb) { :head }
+      let(:request_headers) { {'x-ms-version' => x_ms_version, 'User-Agent' => "#{user_agent_prefix}; #{user_agent}"} }
+
+      before {
+        subject.stubs(:file_uri).with(share_name, directory_path, file_name, query).returns(uri)
+        subject.stubs(:call).with(verb, uri, nil, request_headers, {}).returns(response)
+        serialization.stubs(:file_from_headers).with(response_headers).returns(file)
+      }
+
+      it 'assembles a URI for the request' do
+        subject.expects(:file_uri).with(share_name, directory_path, file_name, query).returns(uri)
+        subject.get_file_properties share_name, directory_path, file_name
+      end
+
+      it 'calls StorageService#call with the prepared request' do
+        subject.expects(:call).with(verb, uri, nil, request_headers, {}).returns(response)
+        subject.get_file_properties share_name, directory_path, file_name
+      end
+
+      it 'returns the file on success' do
+        result = subject.get_file_properties share_name, directory_path, file_name
+
+        result.must_be_kind_of Azure::Storage::File::File
+        result.must_equal file
+        result.name.must_equal file_name
+      end
+    end
+
+    describe '#set_file_metadata' do
+      let(:verb) { :put }
+      let(:file_metadata) { {'MetadataKey' => 'MetaDataValue', 'MetadataKey1' => 'MetaDataValue1'} }
+      let(:request_headers) { {'x-ms-meta-MetadataKey' => 'MetaDataValue', 'x-ms-meta-MetadataKey1' => 'MetaDataValue1', 'x-ms-version' => x_ms_version, 'User-Agent' => "#{user_agent_prefix}; #{user_agent}"} }
+
+      before {
+        query.update({'comp' => 'metadata'})
+        response.stubs(:success?).returns(true)
+        subject.stubs(:file_uri).with(share_name, directory_path, file_name, query).returns(uri)
+        subject.stubs(:call).with(verb, uri, nil, request_headers, {}).returns(response)
+      }
+
+      it 'assembles a URI for the request' do
+        subject.expects(:file_uri).with(share_name, directory_path, file_name, query).returns(uri)
+        subject.set_file_metadata share_name, directory_path, file_name, file_metadata
+      end
+
+      it 'calls StorageService#call with the prepared request' do
+        subject.expects(:call).with(verb, uri, nil, request_headers, {}).returns(response)
+        subject.set_file_metadata share_name, directory_path, file_name, file_metadata
+      end
+
+      it 'returns nil on success' do
+        result = subject.set_file_metadata share_name, directory_path, file_name, file_metadata
+        result.must_equal nil
+      end
+    end
+
+    describe '#get_file_metadata' do
+      let(:verb) { :get }
+      # No header is added in the get_file_metadata. StorageService.call will add common headers.
+      let(:request_headers) { {} }
+      
+      before {
+        query['comp']='metadata'
+
+        subject.stubs(:file_uri).with(share_name, directory_path, file_name, query).returns(uri)
+        subject.stubs(:call).with(verb, uri, nil, request_headers, {}).returns(response)
+        serialization.stubs(:file_from_headers).with(response_headers).returns(file)
+      }
+
+      it 'assembles a URI for the request' do
+        subject.expects(:file_uri).with(share_name, directory_path, file_name, query).returns(uri)
+        subject.get_file_metadata share_name, directory_path, file_name
+      end
+
+      it 'calls StorageService#call with the prepared request' do
+        subject.expects(:call).with(verb, uri, nil, request_headers, {}).returns(response)
+        subject.get_file_metadata share_name, directory_path, file_name
+      end
+
+      it 'returns the file on success' do
+        result = subject.get_file_metadata share_name, directory_path, file_name
+
+        result.must_be_kind_of Azure::Storage::File::File
+        result.must_equal file
+        result.name.must_equal file_name
+      end
+    end
+
+    describe '#get_file' do
+      let(:verb) { :get }
+
+      before {
+        response.stubs(:success?).returns(true)
+        response_body = 'file-contents'
+
+        subject.stubs(:file_uri).with(share_name, directory_path, file_name, query).returns(uri)
+        subject.stubs(:call).with(verb, uri, nil, request_headers, {}).returns(response)
+        serialization.stubs(:file_from_headers).with(response_headers).returns(file)
+      }
+
+      it 'assembles a URI for the request' do
+        subject.expects(:file_uri).with(share_name, directory_path, file_name, query).returns(uri)
+        subject.get_file share_name, directory_path, file_name
+      end
+
+      it 'calls StorageService#call with the prepared request' do
+        subject.expects(:call).with(verb, uri, nil, request_headers, {}).returns(response)
+        subject.get_file share_name, directory_path, file_name
+      end
+
+      it 'returns the file and file contents on success' do
+        returned_file, returned_file_contents = subject.get_file share_name, directory_path, file_name
+
+        returned_file.must_be_kind_of Azure::Storage::File::File
+        returned_file.must_equal file
+        returned_file_contents.must_equal response_body
+      end
+
+      describe "when start_range is provided" do
+        let(:start_range){ 255 }
+        before { request_headers["x-ms-range"]="bytes=#{start_range}-" }
+
+        it "modifies the request headers with the desired range" do
+          subject.expects(:call).with(verb, uri, nil, request_headers, {:start_range => 255}).returns(response)
+          subject.get_file share_name, directory_path, file_name, start_range: start_range
+        end
+      end
+
+      describe "when end_range is provided" do
+        let(:end_range){ 512 }
+        before { request_headers["x-ms-range"]="bytes=0-#{end_range}" }
+
+        it "modifies the request headers with the desired range" do
+          subject.expects(:call).with(verb, uri, nil, request_headers, {:start_range => 0, :end_range => end_range}).returns(response)
+          subject.get_file share_name, directory_path, file_name, start_range: nil, end_range: end_range
+        end
+      end
+
+      describe 'when both start_range and end_range are provided' do
+        let(:start_range) { 255 }
+        let(:end_range) { 512 }
+        before {
+          request_headers['x-ms-range']="bytes=#{start_range}-#{end_range}"
+        }
+
+        it 'modifies the request headers with the desired range' do
+          options = {:start_range => start_range, :end_range => end_range}
+          subject.expects(:call).with(verb, uri, nil, request_headers, options).returns(response)
+          subject.get_file share_name, directory_path, file_name, options
+        end
+      end
+
+      describe 'when get_content_md5 is true' do
+        let(:get_content_md5) { true }
+
+        describe 'and a range is specified' do
+          let(:start_range) { 255 }
+          let(:end_range) { 512 }
+          before {
+            request_headers['x-ms-range']="bytes=#{start_range}-#{end_range}"
+            request_headers['x-ms-range-get-content-md5']= true
+          }
+
+          it 'modifies the request headers to include the x-ms-range-get-content-md5 header' do
+            options = {:start_range => start_range, :end_range => end_range, :get_content_md5 => true}
+            subject.expects(:call).with(verb, uri, nil, request_headers, options).returns(response)
+            subject.get_file share_name, directory_path, file_name, options
+          end
+        end
+
+        describe 'and a range is NOT specified' do
+          it 'does not modify the request headers' do
+            options = {:get_content_md5 => true}
+            subject.expects(:call).with(verb, uri, nil, request_headers, options).returns(response)
+            subject.get_file share_name, directory_path, file_name, options
+          end
+        end
+      end
+    end
+
+    describe '#delete_file' do
+      let(:verb) { :delete }
+      # No header is added in the delete_file. StorageService.call will add common headers.
+      let(:request_headers) { {} }
+
+      before {
+        response.stubs(:success?).returns(true)
+
+        subject.stubs(:file_uri).with(share_name, directory_path, file_name, query).returns(uri)
+        subject.stubs(:call).with(verb, uri, nil, request_headers, {}).returns(response)
+      }
+
+      it 'assembles a URI for the request' do
+        subject.expects(:file_uri).with(share_name, directory_path, file_name, query).returns(uri)
+        subject.delete_file share_name, directory_path, file_name
+      end
+
+      it 'calls StorageService#call with the prepared request' do
+        subject.expects(:call).with(verb, uri, nil, request_headers, {}).returns(response)
+        subject.delete_file share_name, directory_path, file_name
+      end
+
+      it 'returns nil on success' do
+        result = subject.delete_file share_name, directory_path, file_name
+        result.must_equal nil
+      end
+    end
+
+    describe '#copy_file' do
+      let(:verb) { :put }
+      let(:source_share_name) { 'source-share-name' }
+      let(:source_directory_path) { 'source-direcotry-path' }
+      let(:source_file_name) { 'source-file-name' }
+      let(:source_uri) { URI.parse('http://dummy.uri/source') }
+
+      let(:copy_id) { 'copy-id' }
+      let(:copy_status) { 'copy-status' }
+
+      before {
+        request_headers['x-ms-copy-source'] = source_uri.to_s
+        response_headers['x-ms-copy-id'] = copy_id
+        response_headers['x-ms-copy-status'] = copy_status
+
+        subject.stubs(:file_uri).with(share_name, directory_path, file_name, {}).returns(uri)
+        subject.stubs(:file_uri).with(source_share_name, source_directory_path, source_file_name, query).returns(source_uri)
+        subject.stubs(:call).with(verb, uri, nil, request_headers, {}).returns(response)
+      }
+
+      it 'assembles a URI for the request' do
+        subject.expects(:file_uri).with(share_name, directory_path, file_name, {}).returns(uri)
+        subject.copy_file share_name, directory_path, file_name, source_share_name, source_directory_path, source_file_name
+      end
+
+      it 'assembles the source URI and places it in the header' do
+        subject.expects(:file_uri).with(source_share_name, source_directory_path, source_file_name, query).returns(source_uri)
+        subject.copy_file share_name, directory_path, file_name, source_share_name, source_directory_path, source_file_name
+      end
+      
+      it 'calls with source URI' do
+        subject.expects(:file_uri).with(share_name, directory_path, file_name, {}).returns(uri)
+        subject.expects(:call).with(verb, uri, nil, request_headers, {}).returns(response)
+        subject.copy_file_from_uri share_name, directory_path, file_name, source_uri.to_s
+      end
+
+      it 'calls StorageService#call with the prepared request' do
+        subject.expects(:call).with(verb, uri, nil, request_headers, {}).returns(response)
+        subject.copy_file share_name, directory_path, file_name, source_share_name, source_directory_path, source_file_name
+      end
+
+      it 'returns the copy id and copy status on success' do
+        returned_copy_id, returned_copy_status = subject.copy_file share_name, directory_path, file_name, source_share_name, source_directory_path, source_file_name
+        returned_copy_id.must_equal copy_id
+        returned_copy_status.must_equal copy_status
+      end
+
+      describe 'when the options Hash is used' do
+        it 'modifies the request headers when provided a :metadata value' do
+          request_headers['x-ms-meta-MetadataKey'] = 'MetaDataValue'
+          request_headers['x-ms-meta-MetadataKey1'] = 'MetaDataValue1'
+          options = {:metadata => {'MetadataKey' => 'MetaDataValue', 'MetadataKey1' => 'MetaDataValue1'}}
+          subject.expects(:call).with(verb, uri, nil, request_headers, options).returns(response)
+          subject.copy_file share_name, directory_path, file_name, source_share_name, source_directory_path, source_file_name, options
+        end
+
+        it 'does not modify the request headers when provided an unknown value' do
+          options = {:unknown_key => 'some_value'}
+          subject.expects(:call).with(verb, uri, nil, request_headers, options).returns(response)
+          subject.copy_file share_name, directory_path, file_name, source_share_name, source_directory_path, source_file_name, options
+        end
+      end
+    end
+    
+    describe '#abort_copy_file' do
+      let(:verb) { :put }
+      let(:lease_id) { 'lease-id' }
+      let(:copy_id) { 'copy-id' }
+      
+      before {
+        request_headers['x-ms-copy-action'] = 'abort'
+        
+        query.update({'comp' => 'copy', 'copyid' => copy_id})
+        subject.stubs(:file_uri).with(share_name, directory_path, file_name, query).returns(uri)
+      }
+      
+      it 'abort copy a file' do
+        subject.expects(:file_uri).with(share_name, directory_path, file_name, query).returns(uri)
+        subject.abort_copy_file share_name, directory_path, file_name, copy_id
+      end
+    end
+  end
+end

--- a/test/unit/service/storage_service_test.rb
+++ b/test/unit/service/storage_service_test.rb
@@ -159,6 +159,7 @@ describe Azure::Storage::Service::StorageService do
   end
 
   describe '#get_service_properties' do
+    let(:query) { {} }
     let(:service_properties_xml) { Fixtures['storage_service_properties'] }
     let(:service_properties) { Azure::Storage::Service::StorageServiceProperties.new }
     let(:response) {
@@ -171,7 +172,7 @@ describe Azure::Storage::Service::StorageService do
 
     before do
       Azure::Storage::Service::Serialization.stubs(:service_properties_from_xml).with(service_properties_xml).returns(service_properties)
-      subject.stubs(:service_properties_uri).returns(service_properties_uri)
+      subject.stubs(:service_properties_uri).with(query).returns(service_properties_uri)
       subject.stubs(:call).with(:get, service_properties_uri, nil, {}, {}).returns(response)
     end
 
@@ -190,6 +191,15 @@ describe Azure::Storage::Service::StorageService do
       subject.get_service_properties
     end
 
+    it 'modifies the URI query parameters when provided a :timeout value' do
+      query.update({'timeout' => '30'})
+      subject.expects(:service_properties_uri).with(query).returns(service_properties_uri)
+
+      options = {:timeout => 30}
+      subject.expects(:call).with(:get, service_properties_uri, nil, {}, options).returns(response)
+      subject.get_service_properties options
+    end
+
     it 'returns a StorageServiceProperties instance' do
       result = subject.get_service_properties
       result.must_be_kind_of Azure::Storage::Service::StorageServiceProperties
@@ -197,6 +207,7 @@ describe Azure::Storage::Service::StorageService do
   end
 
   describe '#set_service_properties' do
+    let(:query) { {} }
     let(:service_properties_xml) { Fixtures['storage_service_properties'] }
     let(:service_properties) { Azure::Storage::Service::StorageServiceProperties.new }
     let(:response) {
@@ -209,7 +220,7 @@ describe Azure::Storage::Service::StorageService do
 
     before do
       Azure::Storage::Service::Serialization.stubs(:service_properties_to_xml).with(service_properties).returns(service_properties_xml)
-      subject.stubs(:service_properties_uri).returns(service_properties_uri)
+      subject.stubs(:service_properties_uri).with(query).returns(service_properties_uri)
       subject.stubs(:call).with(:put, service_properties_uri, service_properties_xml, {}, {}).returns(response)
     end
 
@@ -221,6 +232,15 @@ describe Azure::Storage::Service::StorageService do
     it 'posts to the HTTP API' do
       subject.expects(:call).with(:put, service_properties_uri, service_properties_xml, {}, {}).returns(response)
       subject.set_service_properties service_properties
+    end
+
+    it 'modifies the URI query parameters when provided a :timeout value' do
+      query.update({'timeout' => '30'})
+      subject.expects(:service_properties_uri).with(query).returns(service_properties_uri)
+
+      options = {:timeout => 30}
+      subject.expects(:call).with(:put, service_properties_uri, service_properties_xml, {}, options).returns(response)
+      subject.set_service_properties service_properties, options
     end
 
     it 'serializes the StorageServiceProperties object to xml' do


### PR DESCRIPTION
ALL
* Fixed the issue where `should_retry?` in the retry_filter.rb overwrites the result from derived `apply_retry_policy`. [#76](https://github.com/Azure/azure-storage-ruby/issues/76)
* Fixed the issue where `Azure::Storage::Client.create_from_connection_string` throws an exception. [#77](https://github.com/Azure/azure-storage-ruby/issues/77)
* Added the support for setting the "timeout" option in `get_service_properties` and `set_service_properties`.

BLOB
* Added the metadata to the returning instance when creates a blob.
* Added `transactional_md5` to the options of `put_blob_pages`.

FILE
* Added File Service support, targeting storage service version 2015-04-05.