### PR TITLE
relax constraint on nokogiri version dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ rvm:
 - 2.1.6
 - 2.2.2
 
+before_install:
+- gem install bundler
+
 script:
 - bundle exec rake test:unit
 - if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ] ; then rake test:integration ; fi

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,8 @@
+Next
+
+ALL
+* Relaxed constraint on Nokogiri version dependency to allow Nokogiri 1.7.x for Ruby 2.1 and later, but preserving support for Ruby 1.9.3. (Note that this may require updating to Bundler 1.13 or later if you're using Ruby 1.9 or 2.0.)
+
 2017.02 - version 0.12.0-preview
 
 ALL

--- a/azure-storage.gemspec
+++ b/azure-storage.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('azure-core',              '~> 0.1')
   s.add_runtime_dependency('faraday',                 '~> 0.9')
   s.add_runtime_dependency('faraday_middleware',      '~> 0.10')
-  s.add_runtime_dependency('nokogiri',                '~> 1.6.0')
+  s.add_runtime_dependency('nokogiri',                '~> 1.6', '< 1.8')
   
   s.add_development_dependency('dotenv',              '~> 2.0')
   s.add_development_dependency('minitest',            '~> 5')


### PR DESCRIPTION
It's understood that the maintainers of this gem want to support older
versions of ruby, which means that users of ruby 1.9 and 2.0 have to use
a pre-1.7.0 version of nokogiri.

However, users of modern rubies should be able to take advantage of the
features and security patches available in nokogiri 1.7.0 and later.

This patch relaxes the constraint so that any version of nokogiri on
1.6.x and 1.7.x release branches is acceptable. Users of the library can
then rely on bundler (via nokogiri's gemspec) to determine the latest
supported version of nokogiri that works for their ruby interpreter.

Note that older version of bundler may not use gems'
`required_ruby_version` declaration to pick the right version. Based on
a cursory examination of Bundler's changelog:

  https://github.com/bundler/bundler/blob/master/CHANGELOG.md

it appears as though bundler 1.13.0.rc.2 (2016-08-21) might be the first
version to respect this constraint.

Thanks for your consideration.
