### PR TITLE
Update for 0.12.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ rvm:
 - 2.1.6
 - 2.2.2
 
+before_install:
+- gem install bundler
+
 script:
 - bundle exec rake test:unit
 - if [ "$TRAVIS_SECURE_ENV_VARS" == "true" ] ; then rake test:integration ; fi

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,8 @@
+Next
+
+ALL
+* Relaxed constraint on Nokogiri version dependency to allow Nokogiri 1.7.x for Ruby 2.1 and later, but preserving support for Ruby 1.9.3. (Note that this may require updating to Bundler 1.13 or later if you're using Ruby 1.9 or 2.0.)
+
 2017.02 - version 0.12.0-preview
 
 ALL

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,4 @@
-Next
+2017.04 - version 0.12.1-preview
 
 ALL
 * Relaxed constraint on Nokogiri version dependency to allow Nokogiri 1.7.x for Ruby 2.1 and later, but preserving support for Ruby 1.9.3. (Note that this may require updating to Bundler 1.13 or later if you're using Ruby 1.9 or 2.0.)

--- a/azure-storage.gemspec
+++ b/azure-storage.gemspec
@@ -41,7 +41,11 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('azure-core',              '~> 0.1')
   s.add_runtime_dependency('faraday',                 '~> 0.9')
   s.add_runtime_dependency('faraday_middleware',      '~> 0.10')
-  s.add_runtime_dependency('nokogiri',                '~> 1.6', '< 1.8')
+  if RUBY_VERSION < "2.1.0"
+    s.add_runtime_dependency('nokogiri',              '~> 1.6.0')
+  else
+    s.add_runtime_dependency('nokogiri',              '~> 1.7', '< 1.8')
+  end
   
   s.add_development_dependency('dotenv',              '~> 2.0')
   s.add_development_dependency('minitest',            '~> 5')

--- a/azure-storage.gemspec
+++ b/azure-storage.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('azure-core',              '~> 0.1')
   s.add_runtime_dependency('faraday',                 '~> 0.9')
   s.add_runtime_dependency('faraday_middleware',      '~> 0.10')
-  s.add_runtime_dependency('nokogiri',                '~> 1.6.0')
+  s.add_runtime_dependency('nokogiri',                '~> 1.6', '< 1.8')
   
   s.add_development_dependency('dotenv',              '~> 2.0')
   s.add_development_dependency('minitest',            '~> 5')

--- a/lib/azure/storage/version.rb
+++ b/lib/azure/storage/version.rb
@@ -28,7 +28,7 @@ module Azure
       # Fields represent the parts defined in http://semver.org/
       MAJOR = 0 unless defined? MAJOR
       MINOR = 12 unless defined? MINOR
-      UPDATE = 0 unless defined? UPDATE
+      UPDATE = 1 unless defined? UPDATE
       PRE = 'preview' unless defined? PRE
 
       class << self


### PR DESCRIPTION
Relaxed constraint on Nokogiri version dependency to allow Nokogiri 1.7.x for Ruby 2.1 and later, but preserving support for Ruby 1.9.3.