### PR TITLE
Ignore blanks in XML parsing - allowing use of azurite emulator

### DIFF
--- a/common/lib/azure/storage/common/service/serialization.rb
+++ b/common/lib/azure/storage/common/service/serialization.rb
@@ -314,7 +314,7 @@ module Azure::Storage::Common
         end
 
         def slopify(xml)
-          node = (xml.is_a? String) ? Nokogiri.Slop(xml).root : xml
+          node = (xml.is_a? String) ? Nokogiri.Slop(xml, nil, nil, Nokogiri::XML::ParseOptions::DEFAULT_XML | Nokogiri::XML::ParseOptions::NOBLANKS ).root : xml
           node.slop! if node.is_a? Nokogiri::XML::Document unless node.respond_to? :method_missing
           node = node.root if node.is_a? Nokogiri::XML::Document
           node


### PR DESCRIPTION
When using this gem along with the azurite emulator (I don't run windows so this is the best one I have found) - fetching the cors configuration caused an error once cors configuration was present.
This was due to xml nodes just containing whitespace (\n character).

This PR simply sets the 'No Blanks' parser option in nokogiri.

I struggled to do any tests for this - the serialization tests seem to stub out internal methods which seemed a bit strange, which meant I could not put a new test in there without changing things around that area.

I tried integration tests, but I could not seem to configure it to use the azurite emulator.

However, the code is working in a real environment with azurite