### PR TITLE
Sign x-ms-copy-source header as well

### DIFF
--- a/common/lib/azure/storage/common/core/auth/shared_access_signature_signer.rb
+++ b/common/lib/azure/storage/common/core/auth/shared_access_signature_signer.rb
@@ -49,9 +49,19 @@ module Azure::Storage::Common::Core
       end
 
       def sign_request(req)
-        req.uri = URI.parse(req.uri.to_s + (req.uri.query.nil? ? "?" : "&") + sas_token.sub(/^\?/, "") + "&api-version=" + @api_ver)
+        if source = req.headers["x-ms-copy-source"]
+          req.headers["x-ms-copy-source"] = sign_uri(URI.parse(source))
+        end
+        req.uri = URI.parse(sign_uri(req.uri))
         req
       end
+
+    private
+
+      def sign_uri(uri)
+        uri.to_s + (uri.query.nil? ? "?" : "&") + sas_token.sub(/^\?/, "") + "&api-version=" + @api_ver
+      end
+
     end
   end
 end


### PR DESCRIPTION
The copy-blob action fails with a 'CannotVerifyCopySource' error when copying a private file. Siging the x-ms-copy-source header fixes that.