### PR TITLE
Bump Nokogiri version

### DIFF
--- a/blob/azure-storage-blob.gemspec
+++ b/blob/azure-storage-blob.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency("azure-core",              "~> 0.1.13")
   s.add_runtime_dependency("azure-storage-common",    "~> 1.0")
-  s.add_runtime_dependency("nokogiri",                "~> 1.6", ">= 1.6.8")
+  s.add_runtime_dependency("nokogiri",                "~> 1.10", ">= 1.10.4")
 
   s.add_development_dependency("dotenv",              "~> 2.0")
   s.add_development_dependency("minitest",            "~> 5")

--- a/common/azure-storage-common.gemspec
+++ b/common/azure-storage-common.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 1.9.3"
 
   s.add_runtime_dependency("azure-core",              "~> 0.1.13")
-  s.add_runtime_dependency("nokogiri",                "~> 1.6", ">= 1.6.8")
+  s.add_runtime_dependency("nokogiri",                "~> 1.10", ">= 1.10.4")
 
   s.add_development_dependency("dotenv",              "~> 2.0")
   s.add_development_dependency("minitest",            "~> 5")

--- a/file/azure-storage-file.gemspec
+++ b/file/azure-storage-file.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency("azure-core",              "~> 0.1.13")
   s.add_runtime_dependency("azure-storage-common",    "~> 1.0")
-  s.add_runtime_dependency("nokogiri",                "~> 1.6", ">= 1.6.8")
+  s.add_runtime_dependency("nokogiri",                "~> 1.10", ">= 1.10.4")
 
   s.add_development_dependency("dotenv",              "~> 2.0")
   s.add_development_dependency("minitest",            "~> 5")

--- a/queue/azure-storage-queue.gemspec
+++ b/queue/azure-storage-queue.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency("azure-core",              "~> 0.1.13")
   s.add_runtime_dependency("azure-storage-common",    "~> 1.0")
-  s.add_runtime_dependency("nokogiri",                "~> 1.6", ">= 1.6.8")
+  s.add_runtime_dependency("nokogiri",                "~> 1.10", ">= 1.10.4")
 
   s.add_development_dependency("dotenv",              "~> 2.0")
   s.add_development_dependency("minitest",            "~> 5")

--- a/table/azure-storage-table.gemspec
+++ b/table/azure-storage-table.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency("azure-core",              "~> 0.1.13")
   s.add_runtime_dependency("azure-storage-common",    "~> 1.0")
-  s.add_runtime_dependency("nokogiri",                "~> 1.6", ">= 1.6.8")
+  s.add_runtime_dependency("nokogiri",                "~> 1.10", ">= 1.10.4")
 
   s.add_development_dependency("dotenv",              "~> 2.0")
   s.add_development_dependency("minitest",            "~> 5")


### PR DESCRIPTION
Nokogiri has a serious security flaw that was fixed on 1.10.4 https://github.com/sparklemotion/nokogiri/issues/1915

I've bumped the nokogiri version is all packages