### PR TITLE
Reuse connection per host

### DIFF
--- a/common/lib/azure/storage/common/core/http_client.rb
+++ b/common/lib/azure/storage/common/core/http_client.rb
@@ -30,7 +30,9 @@ module Azure::Storage::Common::Core
     # @param uri  [URI|String] the base uri (scheme, host, port) of the http endpoint
     # @return [Net::HTTP] http agent for a given uri
     def agents(uri)
-      key = uri.to_s
+      uri = URI(uri) unless uri.is_a? URI
+      key = uri.host
+
       @agents ||= {}
       unless @agents.key?(key)
         @agents[key] = build_http(uri)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -30,7 +30,7 @@ Dotenv.load
 ENV["AZURE_STORAGE_CONNECTION_STRING"] = "DefaultEndpointsProtocol=https;AccountName=mockaccount;AccountKey=bW9ja2tleQ==" unless ENV["AZURE_STORAGE_CONNECTION_STRING"]
 
 require "minitest/autorun"
-require "mocha/mini_test"
+require "mocha/minitest"
 require "minitest/reporters"
 Minitest::Reporters.use! Minitest::Reporters::SpecReporter.new
 require "timecop"

--- a/test/unit/core/http_client_test.rb
+++ b/test/unit/core/http_client_test.rb
@@ -8,6 +8,19 @@ describe Azure::Storage::Common::Core::HttpClient do
   end
 
   describe "#agents" do
+    describe "reusing a connection when connecting to the same host" do
+      let(:client) { Azure::Storage::Common::Client::create }
+
+      it "should use the same connection when reconnecting to the same host" do
+        uri1 = URI("https://management.core.windows.net/uri1")
+        uri2 = URI("https://management.core.windows.net/uri2")
+
+        agent1 = client.agents(uri1)
+        agent2 = client.agents(uri2)
+
+        _(agent1).must_equal agent2
+      end
+    end
 
     describe "ssl vs non ssl uris" do
       it "should set verify true if using ssl" do


### PR DESCRIPTION
Resolves #150 

Maintains a single connection for each host we are connecting to, rather than for each URI.
This significantly reduces the number of connection objects we're keeping around.