### PR TITLE
Add support for identity SAS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ source "https://rubygems.org" do
   gem "faraday_middleware", :require => false
   gem "nokogiri",            "~> 1.10.4", :require => false
 
+  gem "adal",                "~> 1.0", :require => false
   gem "dotenv",              "~> 2.0", :require => false
   gem "minitest",            "~> 5", :require => false
   gem "minitest-reporters",  "~> 1", :require => false

--- a/blob/BreakingChanges.md
+++ b/blob/BreakingChanges.md
@@ -1,3 +1,7 @@
+Tracking Breaking Changes in 2.0.0
+
+* This module now supports Ruby versions to 2.3 through 2.7
+
 Tracking Breaking Changes in 1.0.0
 
 * This module now only consists of functionalities to access Azure Storage Blob Service.

--- a/blob/ChangeLog.md
+++ b/blob/ChangeLog.md
@@ -1,3 +1,7 @@
+2020.3 - version 2.0.0
+* This module now supports Ruby versions to 2.3 through 2.7
+* Add support for generating user delegation shared access signatures.
+
 2018.11 - version 1.1.0
 * Added the support for sending a request with a bearer token.
 

--- a/blob/README.md
+++ b/blob/README.md
@@ -9,12 +9,12 @@ This project provides a Ruby package that makes it easy to access and manage Mic
 
 # Supported Ruby Versions
 
-* Ruby 1.9.3 to 2.5
+* Ruby 2.3 to 2.7
 
 Note: 
 
 * x64 Ruby for Windows is known to have some compatibility issues.
-* azure-storage-blob depends on gem nokogiri. For Ruby version lower than 2.2, please install the compatible nokogiri before trying to install azure-storage-blob.
+* azure-storage-blob depends on gem nokogiri.
 
 # Getting Started
 

--- a/blob/azure-storage-blob.gemspec
+++ b/blob/azure-storage-blob.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.3.0"
 
-  s.add_runtime_dependency("azure-storage-common",    "~> 1.0")
+  s.add_runtime_dependency("azure-storage-common",    "~> 2.0")
   s.add_runtime_dependency("nokogiri",                "~> 1.10.4")
 
   s.add_development_dependency("dotenv",              "~> 2.0")

--- a/blob/lib/azure/storage/blob/default.rb
+++ b/blob/lib/azure/storage/blob/default.rb
@@ -119,6 +119,9 @@ module Azure::Storage::Blob
     # The size of a page, in bytes, in a page blob.
     PAGE_SIZE = 512
 
+    # The maximum validity of user delegation SAS (7 days from the current time).
+    MAX_USER_DELEGATION_KEY_SECONDS = 60 * 60 * 24 * 7
+
     # Resource types.
     module ResourceTypes
       CONTAINER = "c"

--- a/blob/lib/azure/storage/blob/serialization.rb
+++ b/blob/lib/azure/storage/blob/serialization.rb
@@ -49,6 +49,31 @@ module Azure::Storage
         results
       end
 
+      def self.key_info_to_xml(start, expiry)
+        builder = Nokogiri::XML::Builder.new(encoding: "UTF-8") do |xml|
+          xml.KeyInfo {
+            xml.Start start.utc.iso8601
+            xml.Expiry expiry.utc.iso8601
+          }
+        end
+        builder.to_xml
+      end
+
+      def self.user_delegation_key_from_xml(xml)
+        xml = slopify(xml)
+        expect_node("UserDelegationKey", xml)
+
+        Azure::Storage::Common::Service::UserDelegationKey.new do |user_delegation_key|
+          user_delegation_key.signed_oid = xml.SignedOid.text if (xml > "SignedOid").any?
+          user_delegation_key.signed_tid = xml.SignedTid.text if (xml > "SignedTid").any?
+          user_delegation_key.signed_start = xml.SignedStart.text if (xml > "SignedStart").any?
+          user_delegation_key.signed_expiry = xml.SignedExpiry.text if (xml > "SignedExpiry").any?
+          user_delegation_key.signed_service = xml.SignedService.text if (xml > "SignedService").any?
+          user_delegation_key.signed_version = xml.SignedVersion.text if (xml > "SignedVersion").any?
+          user_delegation_key.value = xml.Value.text if (xml > "Value").any?
+        end
+      end
+
       def self.container_from_xml(xml)
         xml = slopify(xml)
         expect_node("Container", xml)

--- a/blob/lib/azure/storage/blob/version.rb
+++ b/blob/lib/azure/storage/blob/version.rb
@@ -29,8 +29,8 @@ module Azure
     module Blob
       class Version
         # Fields represent the parts defined in http://semver.org/
-        MAJOR = 1 unless defined? MAJOR
-        MINOR = 1 unless defined? MINOR
+        MAJOR = 2 unless defined? MAJOR
+        MINOR = 0 unless defined? MINOR
         UPDATE = 0 unless defined? UPDATE
 
         class << self

--- a/common/BreakingChanges.md
+++ b/common/BreakingChanges.md
@@ -1,3 +1,7 @@
+Tracking Breaking Changes in 2.0.0
+
+* This module now supports Ruby versions to 2.3 through 2.7
+
 Tracking Breaking Changes in 1.0.0
 
 * This module now consists of functionalities to support service client library modules.

--- a/common/ChangeLog.md
+++ b/common/ChangeLog.md
@@ -1,3 +1,8 @@
+2020.3 - version 2.0.0
+* This module now supports Ruby versions to 2.3 through 2.7
+* Add support for generating user delegation shared access signatures.
+* Update the storage API version used to generate shared access signatures to 2018-11-09.
+
 2018.11 - version 1.1.0
 * Added the support for sending a request with a bearer token.
 * Added the configuration for SSL versions.

--- a/common/README.md
+++ b/common/README.md
@@ -8,12 +8,12 @@ This project provides a Ruby package that supports service client libraries.
 
 # Supported Ruby Versions
 
-* Ruby 1.9.3 to 2.5
+* Ruby 2.3 to 2.7
 
 Note: 
 
 * x64 Ruby for Windows is known to have some compatibility issues.
-* azure-storage-common depends on gem nokogiri. For Ruby version lower than 2.2, please install the compatible nokogiri before trying to install azure-storage.
+* azure-storage-common depends on gem nokogiri.
 
 # Getting Started
 

--- a/common/lib/azure/storage/common/autoload.rb
+++ b/common/lib/azure/storage/common/autoload.rb
@@ -55,6 +55,7 @@ module Azure
         autoload :StorageService,           "azure/storage/common/service/storage_service"
         autoload :CorsRule,                 "azure/storage/common/service/cors_rule"
         autoload :EnumerationResults,       "azure/storage/common/service/enumeration_results"
+        autoload :UserDelegationKey,        "azure/storage/common/service/user_delegation_key"
       end
     end
   end

--- a/common/lib/azure/storage/common/default.rb
+++ b/common/lib/azure/storage/common/default.rb
@@ -30,7 +30,7 @@ require "azure/storage/common/version"
 module Azure::Storage::Common
   module Default
     # Default REST service (STG) version number. This is used only for SAS generator.
-    STG_VERSION = "2017-11-09"
+    STG_VERSION = "2018-11-09"
 
     # The number of default concurrent requests for parallel operation.
     DEFAULT_PARALLEL_OPERATION_THREAD_COUNT = 1

--- a/common/lib/azure/storage/common/service/user_delegation_key.rb
+++ b/common/lib/azure/storage/common/service/user_delegation_key.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+#-------------------------------------------------------------------------
+# # Copyright (c) Microsoft and contributors. All rights reserved.
+#
+# The MIT License(MIT)
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#--------------------------------------------------------------------------
+
+module Azure::Storage::Common
+  module Service
+    class UserDelegationKey
+      def initialize
+        @signed_oid = nil
+        @signed_tid = nil
+        @signed_start = nil
+        @signed_expiry = nil
+        @signed_service = nil
+        @signed_version = nil
+        @value = nil
+        yield self if block_given?
+      end
+
+      attr_accessor :signed_oid
+      attr_accessor :signed_tid
+      attr_accessor :signed_start
+      attr_accessor :signed_expiry
+      attr_accessor :signed_service
+      attr_accessor :signed_version
+      attr_accessor :value
+    end
+  end
+end

--- a/common/lib/azure/storage/common/version.rb
+++ b/common/lib/azure/storage/common/version.rb
@@ -29,8 +29,8 @@ module Azure
     module Common
       class Version
         # Fields represent the parts defined in http://semver.org/
-        MAJOR = 1 unless defined? MAJOR
-        MINOR = 1 unless defined? MINOR
+        MAJOR = 2 unless defined? MAJOR
+        MINOR = 0 unless defined? MINOR
         UPDATE = 0 unless defined? UPDATE
 
         class << self

--- a/test/integration/auth/user_delegation_key_shared_access_signature_test.rb
+++ b/test/integration/auth/user_delegation_key_shared_access_signature_test.rb
@@ -1,0 +1,76 @@
+#-------------------------------------------------------------------------
+# # Copyright (c) Microsoft and contributors. All rights reserved.
+#
+# The MIT License(MIT)
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files(the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions :
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#--------------------------------------------------------------------------
+require "adal"
+require "azure/storage/common"
+require "azure/storage/common/core/auth/shared_access_signature"
+require "integration/test_helper"
+require "net/http"
+
+describe Azure::Storage::Common::Core::Auth::SharedAccessSignature do
+  subject {
+    tenant_id = ENV.fetch("AZURE_TENANT_ID", nil)
+    client_id = ENV.fetch("AZURE_CLIENT_ID", nil)
+    client_secret = ENV.fetch("AZURE_CLIENT_SECRET", nil)
+    storage_account_name = SERVICE_CREATE_OPTIONS()[:storage_account_name]
+
+    if tenant_id.nil? || client_id.nil? || client_secret.nil?
+      skip "AAD credentials not provided"
+    end
+
+    auth_ctx = ADAL::AuthenticationContext.new("login.microsoftonline.com", tenant_id)
+    client_cred = ADAL::ClientCredential.new(client_id, client_secret)
+    token = auth_ctx.acquire_token_for_client("https://storage.azure.com/", client_cred)
+    access_token = token.access_token
+
+    token_credential = Azure::Storage::Common::Core::TokenCredential.new access_token
+    token_signer = Azure::Storage::Common::Core::Auth::TokenSigner.new token_credential
+    client = Azure::Storage::Common::Client::create(storage_account_name: storage_account_name, signer: token_signer)
+    Azure::Storage::Blob::BlobService.new(api_version: "2018-11-09", client: client)
+  }
+
+  let(:generator) {
+    user_delegation_key = subject.get_user_delegation_key(Time.now - 60 * 5, Time.now + 60 * 15)
+    storage_account_name = SERVICE_CREATE_OPTIONS()[:storage_account_name]
+
+    Azure::Storage::Common::Core::Auth::SharedAccessSignature.new(storage_account_name, "", user_delegation_key)
+  }
+
+  describe "#blob_service_sas_for_container" do
+    let(:container_name) { ContainerNameHelper.name }
+    let(:block_blob_name) { BlobNameHelper.name }
+    let(:content) { content = ""; 512.times.each { |i| content << "@" }; content }
+
+    before {
+      subject.create_container container_name
+      subject.create_block_blob container_name, block_blob_name, content
+    }
+
+    after { ContainerNameHelper.clean }
+
+    it "fetches blob from sas uri" do
+      uri = generator.signed_uri(subject.generate_uri("#{container_name}/#{block_blob_name}"), false, service: "b", permissions: "r", expiry: (Time.now.utc + 60 * 10).iso8601)
+      _(Net::HTTP.get(uri)).must_equal content
+    end
+  end
+end

--- a/test/unit/core/auth/shared_access_signature_test.rb
+++ b/test/unit/core/auth/shared_access_signature_test.rb
@@ -66,6 +66,7 @@ describe Azure::Storage::Common::Core::Auth::SharedAccessSignature do
       _(subject.signable_string_for_service(service_type, path, service_options)).must_equal(
         "rwd\n#{Time.parse('2020-12-10T00:00:00Z').utc.iso8601}\n#{Time.parse('2020-12-11T00:00:00Z').utc.iso8601}\n" +
         "/blob/account-name/example/path\n\n168.1.5.60-168.1.5.70\nhttps,http\n#{Azure::Storage::Common::Default::STG_VERSION}\n" +
+        "b\n\n" +
         "public\ninline, filename=nyan.cat\ngzip\nEnglish\nbinary"
       )
     end


### PR DESCRIPTION
Since API version 2018-11-09, we can use Azure Active Directory credentials to authenticate with storage services which is crucial for enterprise and multi-tenancy use-cases. This pull request adds support for this functionality.

Relevant supporting content:
- [Get User Delegation Key](https://docs.microsoft.com/en-us/rest/api/storageservices/get-user-delegation-key)
- [Create a user delegation SAS](https://docs.microsoft.com/en-us/rest/api/storageservices/create-user-delegation-sas)
- [Python Azure Storage SDK identity SAS implementation](https://github.com/Azure/azure-storage-python/commit/a79f8d846dc10d726fdbd981bbfb40ee46ecb0dd)

When running the integration tests locally, I noticed that a few of them fail with this branch. However, several of the integration tests also fail for me with the current master branch. Any help that you could provide with regards to working on the integration tests would be much appreciated.

This change also adds a new integration test for the identity SAS which requires three new environment variables to be set: `AZURE_TENANT_ID`, `AZURE_CLIENT_ID` and `AZURE_CLIENT_SECRET`. These environment variables specify the Azure Active Directory identity to use for the new integration test. Note that the identity must be granted the "Storage Blob Data Contributor" and "Storage Blob Delegator" permissions on the storage account. The following bash script can be used to set up the required Azure Active Directory configuration and environment variables:

```sh
## create service principal for integration tests

service_principal_name="azure-storage-ruby-integtest"  # CHANGE ME

sp="$(az ad sp create-for-rbac --name "${service_principal_name}" --skip-assignment -o json)"
sp_tenant="$(jq -r '.tenant' <<< "${sp}")"
sp_client="$(jq -r '.appId' <<< "${sp}")"
sp_secret="$(jq -r '.password' <<< "${sp}")"

## assign permissions to service principal

storage_resource_id="$(az storage account show --name "${AZURE_STORAGE_ACCOUNT}" -o json | jq -r '.id')"

while ! az role assignment create --role "Storage Blob Data Contributor" --assignee "${sp_client}" --scope "${storage_resource_id}"; do sleep 2s; done

while ! az role assignment create --role "Storage Blob Delegator" --assignee "${sp_client}" --scope "${storage_resource_id}"; do sleep 2s; done

## export environment variables required for integration tests

export AZURE_TENANT_ID="${sp_tenant}"
export AZURE_CLIENT_ID="${sp_client}"
export AZURE_CLIENT_SECRET="${sp_secret}"
```