### PR TITLE
Use persistent HTTP client to speed up requests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@
 source "https://rubygems.org" do
   gem "faraday",             "~> 1.0", :require => false
   gem "faraday_middleware",  "~> 1.0.0.rc1", :require => false
+  gem "net-http-persistent", "~> 4.0", :require => false
   gem "nokogiri",            "~> 1.10.4", :require => false
 
   gem "adal",                "~> 1.0", :require => false

--- a/common/azure-storage-common.gemspec
+++ b/common/azure-storage-common.gemspec
@@ -43,6 +43,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency('faraday',                 '~> 1.0')
   s.add_runtime_dependency('faraday_middleware',      '~> 1.0.0.rc1')
+  s.add_runtime_dependency("net-http-persistent",     '~> 4.0')
   s.add_runtime_dependency("nokogiri",                "~> 1.10.4")
 
   s.add_development_dependency("dotenv",              "~> 2.0")

--- a/common/lib/azure/storage/common/core/http_client.rb
+++ b/common/lib/azure/storage/common/core/http_client.rb
@@ -72,7 +72,10 @@ module Azure::Storage::Common::Core
                         end || nil
         Faraday.new(uri, ssl: ssl_options, proxy: proxy_options) do |conn|
           conn.use FaradayMiddleware::FollowRedirects
-          conn.adapter Faraday.default_adapter
+          conn.adapter :net_http_persistent, pool_size: 5 do |http|
+            # yields Net::HTTP::Persistent
+            http.idle_timeout = 100
+          end
         end
       end
   end


### PR DESCRIPTION
I have to delete multiple blobs at once. This is quite anoying in Azure
Blob storage in general, since it does not support batch deletes. So I
need to send a request for each delete (multiple thousands in my case).

The problem is made much worse by this library not keeping its HTTP
connections open for successive requests. This commit fixes that by
using the `Net:HTTP::Persistent` adapter from Faraday.

This makes sending multiple requests much faster. On a bad connection it
also causes less errors, since a connection timeout can only happen
once. After connecting successfully the connection will continue
working as TCP will handle any hicups, instead of getting `ETIMEDOUT`
errors.