### PR TITLE
Update faraday_middleware and nokogiri to latest versions

### DIFF
--- a/common/azure-storage-common.gemspec
+++ b/common/azure-storage-common.gemspec
@@ -42,12 +42,12 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.3.0"
 
   s.add_runtime_dependency('faraday',                 '~> 1.0')
-  s.add_runtime_dependency('faraday_middleware',      '~> 1.0.0.rc1')
+  s.add_runtime_dependency('faraday_middleware',      '~> 1.0')
   s.add_runtime_dependency("net-http-persistent",     '~> 4.0')
   if RUBY_VERSION < "2.4.0"
     s.add_runtime_dependency("nokogiri",                "~> 1.10.4")
   else
-    s.add_runtime_dependency("nokogiri",                "~> 1.11.0.rc2")
+    s.add_runtime_dependency("nokogiri",                "~> 1.11.0.rc3")
   end
 
   s.add_development_dependency("dotenv",              "~> 2.0")


### PR DESCRIPTION
faraday_middleware      ~> 1.0.0.rc1   =>   ~>1.0.0
nokogiri                         ~> 1.11.0.rc2  =>   ~> 1.11.0.rc3