### PR TITLE
Define PRIVATE_RANGES in IPAddr class

### DIFF
--- a/common/lib/azure/storage/common/core/utility.rb
+++ b/common/lib/azure/storage/common/core/utility.rb
@@ -213,6 +213,12 @@ end
 
 # Code validate private/public IP acceptable ranges.
 class IPAddr
+  PRIVATE_RANGES = [
+    IPAddr.new('10.0.0.0/8'),
+    IPAddr.new('172.16.0.0/12'),
+    IPAddr.new('192.168.0.0/16')
+  ]
+
   def private?
     return false unless self.ipv4?
     PRIVATE_RANGES.each do |ipr|


### PR DESCRIPTION
This class appears to be a duplicate of the IPAddr class found in common/lib/azure/core/utility.rb, however this version does not define the constant PRIVATE_RANGES.  This is manifesting as an error that appears as follows:

```
E, [2021-03-29T01:34:52.651460 #756] ERROR -- : app error: uninitialized constant IPAddr::PRIVATE_RANGES (NameError)
E, [2021-03-29T01:34:52.651585 #756] ERROR -- : /var/www/discourse/plugins/discourse-azure-blob-storage/gems/2.7.2/gems/azure-storage-common-2.0.2/lib/azure/storage/common/core/utility.rb:218:in `private?'
```

I'm not 100% sure why this is manifesting now in my usage where it didn't before, but I believe this to be the root cause.  Please let me know if you have any questions.