### PR TITLE
added access tier information and creation time of blob in response

### DIFF
--- a/blob/lib/azure/storage/blob/serialization.rb
+++ b/blob/lib/azure/storage/blob/serialization.rb
@@ -199,6 +199,9 @@ module Azure::Storage
 
         props = {}
 
+        props[:access_tier] = (xml > "AccessTier").text if (xml > "AccessTier").any?
+        props[:access_tier_change_time] = (xml > "AccessTierChangeTime").text if (xml > "AccessTierChangeTime").any?
+        props[:creation_Time] = (xml > "Creation-Time").text if (xml > "Creation-Time").any?
         props[:last_modified] = (xml > "Last-Modified").text if (xml > "Last-Modified").any?
         props[:etag] = xml.Etag.text if (xml > "Etag").any?
         props[:lease_status] = xml.LeaseStatus.text if (xml > "LeaseStatus").any?


### PR DESCRIPTION
Blob list api not returning Access Tier information(HOT, COOL, ARCHIVE)  in response, it is present in xml so I have added these information in API. so that we will know Access tier and Access tier change date for individual blob.