### PR TITLE
Guard against nil value for x-ms-blob-content-type

### DIFF
--- a/blob/lib/azure/storage/blob/block.rb
+++ b/blob/lib/azure/storage/blob/block.rb
@@ -411,7 +411,7 @@ module Azure::Storage
 
         StorageService.add_metadata_to_headers options[:metadata], headers
         add_blob_conditional_headers options, headers
-        headers["x-ms-blob-content-type"] = get_or_apply_content_type(content, options[:content_type])
+        StorageService.with_header headers, "x-ms-blob-content-type", get_or_apply_content_type(content, options[:content_type])
         # call PutBlob
         response = call(:put, uri, content, headers, options)
 


### PR DESCRIPTION
This PR just adds usage of `StorageService.with_header` for `x-ms-content-type`, so it behaves the same as other headers