### PR TITLE
Support `NO_PROXY` environment variable and fix `HTTP_PROXY/HTTPS_PROXY` behaviour

### DIFF
--- a/common/lib/azure/storage/common/core/http_client.rb
+++ b/common/lib/azure/storage/common/core/http_client.rb
@@ -65,12 +65,7 @@ module Azure::Storage::Common::Core
           ssl_options[:ca_file] = self.ca_file if self.ca_file
           ssl_options[:verify] = true
         end
-        proxy_options = if ENV["HTTP_PROXY"]
-                          URI::parse(ENV["HTTP_PROXY"])
-                        elsif ENV["HTTPS_PROXY"]
-                          URI::parse(ENV["HTTPS_PROXY"])
-                        end || nil
-        Faraday.new(uri, ssl: ssl_options, proxy: proxy_options) do |conn|
+        Faraday.new(uri, ssl: ssl_options) do |conn|
           conn.use FaradayMiddleware::FollowRedirects
           conn.adapter :net_http_persistent, pool_size: 5 do |http|
             # yields Net::HTTP::Persistent


### PR DESCRIPTION
Hi 👋 

Currently there is support for `HTTP/HTTPS_PROXY` behaviour. But unfortunately not for the `NO_PROXY` environment variable.

Faraday has native support for all the above parameters since 0.12 (https://github.com/lostisland/faraday/blob/main/CHANGELOG.md#v0120). So there is no need to configure it manually anymore.

I've update the tests so there are tests for the `NO_PROXY` parameter, but also noticed there was a mistake in the tests. When only `HTTP_PROXY` is configured, then there should be no proxy being used for `https://` websites. This should be done by the `HTTPS_PROXY` parameter. I've updated the tests to correct this.