### PR TITLE
Use CGI.escape instead

### DIFF
--- a/table/lib/azure/storage/table/table_service.rb
+++ b/table/lib/azure/storage/table/table_service.rb
@@ -741,14 +741,8 @@ module Azure::Storage
 
       protected
         def encodeODataUriValue(value)
-          # Replace each single quote (') with double single quotes ('') not double
-          # quotes (")
-          value = value.gsub("'", "''")
-
           # Encode the special URL characters
-          value = URI.escape(value)
-
-          value
+          CGI.escape(value)
         end
 
       protected


### PR DESCRIPTION
While using Ruby 3.1 we encountered `undefined method escape' for URI:Module (NoMethodError)`. Utilizing `CGI.escape` in lieu of manually escaping single quotes and using `URI.escape` seems to work as expected and should allow this library to work with modern Ruby versions! 🎉 