### PR TITLE
Configurable Persistent HTTP Pool

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,7 @@ You can use the following commands to run:
 * All the tests: ``rake test``. **This will run integration tests if you have .env file or env vars setup**
 * Run storage suite of tests: ``rake test:unit``, ``rake test:integration``
 * One particular test file: ``ruby -I".\blob\lib;.\common\lib;.\table\lib;.\queue\lib;.\file\lib;test" "<path of the test file>"``
+* Use ``MT_COMPAT=1 rake test`` environment variable in case you get ``NameError: uninitialized constant MiniTest`` (see https://github.com/minitest/minitest/commit/a2c6c18570f6f0a1bf6af70fe3b6d9599a13fdd6)
 
 ### Testing Features
 As you develop a feature, you'll need to write tests to ensure quality. Your changes should be covered by both unit tests and integration tests. You should also run existing tests related to your change to address any unexpected breaks.

--- a/common/lib/azure/storage/common/core/http_client.rb
+++ b/common/lib/azure/storage/common/core/http_client.rb
@@ -72,7 +72,7 @@ module Azure::Storage::Common::Core
                         end || nil
         Faraday.new(uri, ssl: ssl_options, proxy: proxy_options) do |conn|
           conn.use FaradayMiddleware::FollowRedirects
-          conn.adapter :net_http_persistent, pool_size: 5 do |http|
+          conn.adapter :net_http_persistent, pool_size: ENV.fetch('AZURE_STORAGE_HTTP_POOL', 5).to_i do |http|
             # yields Net::HTTP::Persistent
             http.idle_timeout = 100
           end

--- a/common/lib/azure/storage/common/service/storage_service.rb
+++ b/common/lib/azure/storage/common/service/storage_service.rb
@@ -239,8 +239,8 @@ module Azure::Storage::Common
 
         # Registers the callback when sending the request
         # The headers in the request can be viewed or changed in the code block
-        def register_request_callback
-          @request_callback = Proc.new
+        def register_request_callback(&block)
+          @request_callback = proc &block
         end
 
         # Get the request location.

--- a/test/unit/core/http_client_test.rb
+++ b/test/unit/core/http_client_test.rb
@@ -63,5 +63,24 @@ describe Azure::Storage::Common::Core::HttpClient do
         _(Azure::Storage::Common::Client::create.agents(uri).proxy.uri).must_equal https_proxy_uri
       end
     end
+
+    describe "when net_http_persistent pool is set" do
+      let(:pool_size) { 10 }
+
+      before do
+        ENV["AZURE_STORAGE_HTTP_POOL"] = pool_size.to_s
+      end
+
+      after do
+        ENV["AZURE_STORAGE_HTTP_POOL"] = nil
+      end
+
+      it "should set the pool size for connection" do
+        agent = Azure::Storage::Common::Client::create.agents(uri)
+        size = agent.builder.adapter.instance_variable_get(:@args)[0][:pool_size]
+
+        _(size).must_equal pool_size
+      end
+    end
   end
 end


### PR DESCRIPTION
Adds the possibility to configure the `Net::HTTP::Persistent` pool size. It is required if your Rails application works in multithreaded mode and amount of threads is more than the default 5.